### PR TITLE
Fix DimensionSelection, reset the slider also when maximum was unchanged

### DIFF
--- a/src/DimensionSelectionWidget.cpp
+++ b/src/DimensionSelectionWidget.cpp
@@ -271,9 +271,8 @@ namespace hdps
                 {
                     slider.setMaximum(newMaximum);
                     qDebug() << "Dimension Selection slider maximum value: " << newMaximum;
-                    slider.setValue(isSliderValueAtMaximum ? newMaximum : 0);
-
                 }
+                slider.setValue(isSliderValueAtMaximum ? newMaximum : 0);
             }
             else
             {


### PR DESCRIPTION
Bug found by Jeroen Eggermont, by toggling the "Ignore zero values" check box when the slider was somewhere in the middle.