### PR TITLE
Replace Qt emit from TsneSettingsWidget by direct function call

### DIFF
--- a/src/TsneAnalysisPlugin.cpp
+++ b/src/TsneAnalysisPlugin.cpp
@@ -1,4 +1,5 @@
 #include "TsneAnalysisPlugin.h"
+#include "TsneSettingsWidget.h"
 
 #include "PointData.h"
 
@@ -15,6 +16,11 @@ Q_PLUGIN_METADATA(IID "nl.tudelft.TsneAnalysisPlugin")
 // =============================================================================
 
 using namespace hdps;
+TsneAnalysisPlugin::TsneAnalysisPlugin()
+:
+AnalysisPlugin("tSNE Analysis")
+{
+}
 
 TsneAnalysisPlugin::~TsneAnalysisPlugin(void)
 {
@@ -23,13 +29,11 @@ TsneAnalysisPlugin::~TsneAnalysisPlugin(void)
 
 void TsneAnalysisPlugin::init()
 {
-    _settings = std::make_unique<TsneSettingsWidget>();
+    _settings = std::make_unique<TsneSettingsWidget>(*this);
 
     connect(_settings.get(), &TsneSettingsWidget::dataSetPicked, this, &TsneAnalysisPlugin::dataSetPicked);
     connect(_settings.get(), &TsneSettingsWidget::knnAlgorithmPicked, this, &TsneAnalysisPlugin::onKnnAlgorithmPicked);
     connect(_settings.get(), &TsneSettingsWidget::distanceMetricPicked, this, &TsneAnalysisPlugin::onDistanceMetricPicked);
-    connect(_settings.get(), &TsneSettingsWidget::startComputation, this, &TsneAnalysisPlugin::startComputation);
-    connect(_settings.get(), &TsneSettingsWidget::stopComputation, this, &TsneAnalysisPlugin::stopComputation);
     connect(&_tsne, &TsneAnalysis::computationStopped, _settings.get(), &TsneSettingsWidget::computationStopped);
     connect(&_tsne, SIGNAL(newEmbedding()), this, SLOT(onNewEmbedding()));
 }

--- a/src/TsneAnalysisPlugin.h
+++ b/src/TsneAnalysisPlugin.h
@@ -3,7 +3,7 @@
 #include <AnalysisPlugin.h>
 
 #include "TsneAnalysis.h"
-#include "TsneSettingsWidget.h"
+class TsneSettingsWidget;
 
 using namespace hdps::plugin;
 using namespace hdps::gui;
@@ -16,7 +16,7 @@ class TsneAnalysisPlugin : public QObject, public AnalysisPlugin
 {
     Q_OBJECT   
 public:
-    TsneAnalysisPlugin() : AnalysisPlugin("tSNE Analysis") { }
+    TsneAnalysisPlugin();
     ~TsneAnalysisPlugin(void) override;
     
     void init() override;
@@ -28,16 +28,18 @@ public:
     hdps::DataTypes supportedDataTypes() const Q_DECL_OVERRIDE;
 
     SettingsWidget* const getSettings() override;
+
+    void startComputation();
+    void stopComputation();
+
 public slots:
     void dataSetPicked(const QString& name);
     void onKnnAlgorithmPicked(const int index);
     void onDistanceMetricPicked(const int index);
-    void startComputation();
     void onNewEmbedding();
 
 private:
     void initializeTsne();
-    void stopComputation();
 
     TsneAnalysis _tsne;
     std::unique_ptr<TsneSettingsWidget> _settings;

--- a/src/TsneSettingsWidget.cpp
+++ b/src/TsneSettingsWidget.cpp
@@ -1,6 +1,7 @@
 #include "TsneSettingsWidget.h"
 
 #include "DimensionSelectionWidget.h"
+#include "TsneAnalysisPlugin.h"
 
 // Qt header files:
 #include <QDebug>
@@ -14,7 +15,9 @@
 
 
 
-TsneSettingsWidget::TsneSettingsWidget()
+TsneSettingsWidget::TsneSettingsWidget(TsneAnalysisPlugin& analysisPlugin)
+:
+_analysisPlugin(analysisPlugin)
 {
     const auto minimumWidth = 200;
     setMinimumWidth(minimumWidth);
@@ -194,7 +197,7 @@ void TsneSettingsWidget::onStartToggled(bool pressed)
         }
     }
     startButton.setText(pressed ? "Stop Computation" : "Start Computation");
-    emit pressed ? startComputation() : stopComputation();
+    pressed ? _analysisPlugin.startComputation() : _analysisPlugin.stopComputation();;
 }
 
 void TsneSettingsWidget::numIterationsChanged(const QString &)

--- a/src/TsneSettingsWidget.h
+++ b/src/TsneSettingsWidget.h
@@ -37,7 +37,7 @@ public:
     TsneSettingsWidget& operator=(const TsneSettingsWidget&) = delete;
     TsneSettingsWidget& operator=(TsneSettingsWidget&&) = delete;
 
-    TsneSettingsWidget();
+    explicit TsneSettingsWidget(TsneAnalysisPlugin&);
 
     std::vector<bool> getEnabledDimensions();
     bool hasValidSettings();
@@ -48,8 +48,6 @@ private:
     void checkInputStyle(QLineEdit& input);
 
 signals:
-    void startComputation();
-    void stopComputation();
     void dataSetPicked(QString);
     void knnAlgorithmPicked(int);
     void distanceMetricPicked(int);
@@ -81,4 +79,6 @@ public:
     QLineEdit numChecks;
     QLineEdit theta;
     QPushButton startButton;
+private:
+  TsneAnalysisPlugin& _analysisPlugin;
 };


### PR DESCRIPTION
Replaces Qt emit of `startComputation()` and `stopComputation()` in `TsneSettingsWidget` by direct function calls to those `TsneAnalysisPlugin` member functions.

Exceptions get propagated properly from a C++ function call, but they may not propagate from a slot function to the function that emitted the signal, as remarked by @JulianThijssen

See also https://doc.qt.io/qt-5.12/exceptionsafety.html#exceptions-in-client-code