### PR TITLE
Remove deprecated Points::operator[] calls from TsneAnalysisPlugin

### DIFF
--- a/src/TsneAnalysisPlugin.cpp
+++ b/src/TsneAnalysisPlugin.cpp
@@ -120,16 +120,21 @@ void TsneAnalysisPlugin::startComputation()
 
     data.reserve(selection.size() * numDimensions);
 
-    for (const auto& pointId : selection)
-    {
-        for (int dimensionId = 0; dimensionId < points.getNumDimensions(); dimensionId++)
+    const auto numDimensionsOfPoints = points.getNumDimensions();
+
+    points.visitFromBeginToEnd([&data, &selection, &enabledDimensions, numDimensionsOfPoints](auto beginOfData, auto endOfData)
         {
-            if (enabledDimensions[dimensionId]) {
-                const auto index = pointId * points.getNumDimensions() + dimensionId;
-                data.push_back(points[index]);
+            for (const auto& pointId : selection)
+            {
+                for (int dimensionId = 0; dimensionId < numDimensionsOfPoints; dimensionId++)
+                {
+                    if (enabledDimensions[dimensionId]) {
+                        const auto index = pointId * numDimensionsOfPoints + dimensionId;
+                        data.push_back(beginOfData[index]);
+                    }
+                }
             }
-        }
-    }
+        });
 
     _embeddingName = _core->createDerivedData("Points", "Embedding", points.getName());
     Points& embedding = _core->requestData<Points>(_embeddingName);


### PR DESCRIPTION
Replace `Points::operator[]` calls within the `computeStatisticsPushButton` handler of `DimensionSelectionWidget`, and `TsneAnalysisPlugin::startComputation()`, by `Points::visitFromBeginToEnd`

Fixes a warning, introduced by HDPS core pull request #65 (Support bfloat16 and small integer types as data element type of PointData), which said:

> warning C4996: 'Points::operator []': Deprecated: Assumes that point data is always 32-bit float!

Allows supporting point data element types other than `float`.