### PR TITLE
No more hard coded _exponential_decay_iter

### DIFF
--- a/Common/TsneAnalysis.cpp
+++ b/Common/TsneAnalysis.cpp
@@ -59,6 +59,7 @@ _iterations(1000),
 _numTrees(4),
 _numChecks(1024),
 _exaggerationIter(250),
+_exponentialDecayIter(150),
 _perplexity(30),
 _numDimensionsOutput(2),
 _verbose(false),
@@ -156,7 +157,7 @@ void TsneAnalysis::initGradientDescent()
     tsneParams._embedding_dimensionality = _numDimensionsOutput;
     tsneParams._mom_switching_iter = _exaggerationIter;
     tsneParams._remove_exaggeration_iter = _exaggerationIter;
-    tsneParams._exponential_decay_iter = 150;
+    tsneParams._exponential_decay_iter = _exponentialDecayIter;
     tsneParams._exaggeration_factor = 4 + _numPoints / 60000.0;
     _A_tSNE.setTheta(std::min(0.5, std::max(0.0, (_numPoints - 1000.0)*0.00005)));
 
@@ -292,6 +293,11 @@ void TsneAnalysis::setNumChecks(int numChecks)
 void TsneAnalysis::setExaggerationIter(int exaggerationIter)
 {
     _exaggerationIter = exaggerationIter;
+}
+
+void TsneAnalysis::setExponentialDecayIter(int exponentialDecayIter)
+{
+    _exponentialDecayIter = exponentialDecayIter;
 }
 
 void TsneAnalysis::setPerplexity(int perplexity)

--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -25,6 +25,7 @@ public:
     void setNumTrees(int numTrees);
     void setNumChecks(int numChecks);
     void setExaggerationIter(int exaggerationIter);
+    void setExponentialDecayIter(int exponentialDecayIter);
     void setPerplexity(int perplexity);
     void setNumDimensionsOutput(int numDimensionsOutput);
 
@@ -80,6 +81,7 @@ private:
     int _numTrees;
     int _numChecks;
     int _exaggerationIter;
+    int _exponentialDecayIter;
     int _perplexity;
     int _numDimensionsOutput;
 

--- a/tSNE/src/TsneAnalysisPlugin.cpp
+++ b/tSNE/src/TsneAnalysisPlugin.cpp
@@ -174,6 +174,7 @@ void TsneAnalysisPlugin::initializeTsne() {
     _tsne.setIterations(_settings->numIterations.text().toInt());
     _tsne.setPerplexity(_settings->perplexity.text().toInt());
     _tsne.setExaggerationIter(_settings->exaggeration.text().toInt());
+    _tsne.setExponentialDecayIter(_settings->expDecay.text().toInt());
     _tsne.setNumTrees(_settings->numTrees.text().toInt());
     _tsne.setNumChecks(_settings->numChecks.text().toInt());
 }


### PR DESCRIPTION
You could set the exponential decay iterations to remove the exaggeration in the GUI without any effect since it was hard coded.

This fixes that.