### PR TITLE
Fix duplicate symmetrization of probability distribution

### DIFF
--- a/Common/TsneAnalysis.cpp
+++ b/Common/TsneAnalysis.cpp
@@ -14,7 +14,7 @@
 TsneWorker::TsneWorker(TsneParameters parameters, const std::vector<hdi::data::MapMemEff<uint32_t, float>>& probDist, int numPoints, int numDimensions) :
     _currentIteration(0),
     _parameters(parameters),
-    _probabilityDistribution(probDist),
+    _jointProbabilityDistribution(probDist),
     _numPoints(numPoints),
     _numDimensions(numDimensions),
     _hasProbabilityDistribution(true),
@@ -74,8 +74,8 @@ void TsneWorker::computeSimilarities()
 
     emit progressSection("Calculate probability distributions");
 
-    _probabilityDistribution.clear();
-    _probabilityDistribution.resize(_numPoints);
+    _jointProbabilityDistribution.clear();
+    _jointProbabilityDistribution.resize(_numPoints);
     qDebug() << "Sparse matrix allocated.";
 
     qDebug() << "Computing high dimensional probability distributions.. Num dims: " << _numDimensions << " Num data points: " << _numPoints;
@@ -83,7 +83,7 @@ void TsneWorker::computeSimilarities()
     double t = 0.0;
     {
         hdi::utils::ScopedTimer<double> timer(t);
-        probabilityGenerator.computeJointProbabilityDistribution(_data.data(), _numDimensions, _numPoints, _probabilityDistribution, probGenParams);
+        probabilityGenerator.computeJointProbabilityDistribution(_data.data(), _numDimensions, _numPoints, _jointProbabilityDistribution, probGenParams);
     }
 
     emit progressSection("Probability distributions calculated");
@@ -114,7 +114,7 @@ void TsneWorker::computeGradientDescent(int iterations)
     // Initialize GPGPU-SNE
     _offscreenBuffer->bindContext();
     if (_currentIteration == 0)
-        _GPGPU_tSNE.initialize(_probabilityDistribution, &_embedding, tsneParameters);
+        _GPGPU_tSNE.initializeWithJointProbabilityDistribution(_jointProbabilityDistribution, &_embedding, tsneParameters);
 
     copyEmbeddingOutput();
     emit embeddingUpdate(_outEmbedding);

--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -55,7 +55,7 @@ private:
     std::vector<float> _data;
 
     /** High-dimensional probability distribution encoding point similarities */
-    hdi::dr::HDJointProbabilityGenerator<float>::sparse_scalar_matrix_type _probabilityDistribution;
+    hdi::dr::HDJointProbabilityGenerator<float>::sparse_scalar_matrix_type _jointProbabilityDistribution;
 
     /** Check if the worker was initialized with a probability distribution or data */
     bool _hasProbabilityDistribution;


### PR DESCRIPTION
`probabilityGenerator.computeJointProbabilityDistribution` already symmetrizes `_probabilityDistribution` but `_GPGPU_tSNE.initialize` does it again.

The only difference in `_GPGPU_tSNE.initializeWithJointProbabilityDistribution` is that it does not repeat the symmetrization. 