### PR TITLE
Fix duplicate symmetrization of probability distribution

### DIFF
--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -55,7 +55,7 @@ private:
     std::vector<float> _data;
 
     /** High-dimensional probability distribution encoding point similarities */
-    hdi::dr::HDJointProbabilityGenerator<float>::sparse_scalar_matrix_type _jointProbabilityDistribution;
+    hdi::dr::HDJointProbabilityGenerator<float>::sparse_scalar_matrix_type _probabilityDistribution;
 
     /** Check if the worker was initialized with a probability distribution or data */
     bool _hasProbabilityDistribution;


### PR DESCRIPTION
`probabilityGenerator.computeJointProbabilityDistribution` already symmetrizes `_probabilityDistribution` but `_GPGPU_tSNE.initialize` does it again.

The only difference in `_GPGPU_tSNE.initializeWithJointProbabilityDistribution` is that it does not repeat the symmetrization.
