### PR TITLE
offscreenBuffer initialize in main thread

### DIFF
--- a/Common/TsneAnalysis.cpp
+++ b/Common/TsneAnalysis.cpp
@@ -59,7 +59,7 @@ void TsneWorker::changeThread(QThread* targetThread)
     //_task->moveToThread(targetThread);
 
     
-
+    _offscreenBuffer->initialize();
     // Move the Offscreen buffer to the processing thread after creating it in the UI Thread
     _offscreenBuffer->moveToThread(targetThread);
 }
@@ -243,13 +243,6 @@ void TsneWorker::compute()
     double t = 0.0;
     {
         hdi::utils::ScopedTimer<double> timer(t);
-
-        _tasks->getInitializeOffScreenBufferTask().setRunning();
-
-        // Create a context local to this thread that shares with the global share context
-        _offscreenBuffer->initialize();
-        
-        _tasks->getInitializeOffScreenBufferTask().setFinished();
 
         if (!_hasProbabilityDistribution)
             computeSimilarities();

--- a/Common/TsneAnalysis.cpp
+++ b/Common/TsneAnalysis.cpp
@@ -58,8 +58,10 @@ void TsneWorker::changeThread(QThread* targetThread)
     
     //_task->moveToThread(targetThread);
 
-    
+#ifdef __APPLE__
+    // On macOS initialize OpenGL context in main thread
     _offscreenBuffer->initialize();
+#endif // __APPLE__
     // Move the Offscreen buffer to the processing thread after creating it in the UI Thread
     _offscreenBuffer->moveToThread(targetThread);
 }
@@ -243,6 +245,15 @@ void TsneWorker::compute()
     double t = 0.0;
     {
         hdi::utils::ScopedTimer<double> timer(t);
+
+#ifndef __APPLE__
+        _tasks->getInitializeOffScreenBufferTask().setRunning();
+
+        // Create a context local to this thread that shares with the global share context
+        _offscreenBuffer->initialize();
+        
+        _tasks->getInitializeOffScreenBufferTask().setFinished();
+#endif // Not __APPLE __
 
         if (!_hasProbabilityDistribution)
             computeSimilarities();


### PR DESCRIPTION
Move initialization of the offscreenBuffer (which sets an openGL context to current) to the main thread. This fixes a macOS crash due to a UI operation not from the UI (main) thread