### PR TITLE
Fix crash on saving un-initialized HSNE

### DIFF
--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -333,7 +333,7 @@ QVariantMap HsneAnalysisPlugin::toVariantMap() const
 
     _hsneSettingsAction->insertIntoVariantMap(variantMap);
 
-    if (_hsneSettingsAction->getHierarchyConstructionSettingsAction().getSaveHierarchyToProjectAction().isChecked())
+    if (_hsneSettingsAction->getHierarchyConstructionSettingsAction().getSaveHierarchyToProjectAction().isChecked() && _hierarchy.isInitialized())
     {
         // Handle HSNE Hierarchy
         {


### PR DESCRIPTION
- Check if HSNE hierarchy is initialized before serializing it