### PR TITLE
Allow HSNE analysis to be safely removed

### DIFF
--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -49,6 +49,8 @@ public:
      */
     HsneScaleAction(QObject* parent, TsneParameters& tsneParameters, HsneHierarchy& hsneHierarchy, Dataset<Points> inputDataset, Dataset<Points> embeddingDataset);
 
+    ~HsneScaleAction();
+
     /**
      * Get the context menu for the action
      * @param parent Parent widget
@@ -95,7 +97,7 @@ public: // Serialization
 
 private:
     using Datasets = std::vector<Dataset<Points>>;
-    using RefineActions = std::vector<std::unique_ptr<HsneScaleAction>>;
+    using RefineActions = std::vector<HsneScaleAction*>;
 
 private:
     TsneParameters&         _tsneParameters;        /** Reference to TSNE paremeters from the HSNE analysis */

--- a/HSNE/src/HsneSettingsAction.cpp
+++ b/HSNE/src/HsneSettingsAction.cpp
@@ -14,7 +14,7 @@ HsneSettingsAction::HsneSettingsAction(HsneAnalysisPlugin* hsneAnalysisPlugin) :
     _hierarchyConstructionSettingsAction(*this),
     _gradientDescentSettingsAction(this, _tsneParameters),
     _knnSettingsAction(this, _knnParameters),
-    _topLevelScaleAction(this, _tsneParameters, hsneAnalysisPlugin->getHierarchy(), hsneAnalysisPlugin->getInputDataset<Points>(), hsneAnalysisPlugin->getOutputDataset<Points>())
+    _topLevelScaleAction(nullptr, _tsneParameters, hsneAnalysisPlugin->getHierarchy(), hsneAnalysisPlugin->getInputDataset<Points>(), hsneAnalysisPlugin->getOutputDataset<Points>())
 {
     const auto updateReadOnly = [this]() -> void {
         _generalHsneSettingsAction.setReadOnly(isReadOnly());


### PR DESCRIPTION
The unique pointer to HSNE scale action(s) is the culprit. As the HSNE scale actions are part of the Qt object tree, each scale action is alive as long as its parent is alive (Qt takes care of the deletion). So there is no need to remove the HSNE scale actions again with the unique pointer. I propose to replace the `std::unique_ptr` with a raw pointer. From what I tested with this approach, the HSNE analysis plugin can be safely removed.