### PR TITLE
Fix some saving and loading issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # Library versions
 # -----------------------------------------------------------------------------
 set(HDILib_VERSION 1.2.6)
-set(flann_VERSION 1.9.1)
+set(flann_VERSION 1.9.2)
 set(lz4_VERSION 1.9.3)
 
 # -----------------------------------------------------------------------------

--- a/Common/GradientDescentSettingsAction.cpp
+++ b/Common/GradientDescentSettingsAction.cpp
@@ -27,17 +27,7 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
         _tsneParameters.setExponentialDecayIter(_exponentialDecayAction.getValue());
     };
 
-    const auto isResettable = [this]() -> bool {
-        if (_exaggerationAction.isResettable())
-            return true;
-
-        if (_exponentialDecayAction.isResettable())
-            return true;
-
-        return false;
-    };
-
-    const auto updateReadOnly = [this, isResettable]() -> void {
+    const auto updateReadOnly = [this]() -> void {
         const auto enable = !isReadOnly();
 
         _exaggerationAction.setEnabled(enable);

--- a/Common/GradientDescentSettingsAction.h
+++ b/Common/GradientDescentSettingsAction.h
@@ -44,7 +44,7 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 protected:
-    TsneParameters&         _tsneParameters;            /** Pointer to tSNE parameters */
+    TsneParameters&         _tsneParameters;            /** Reference to tSNE parameters */
     IntegralAction          _exaggerationAction;        /** Exaggeration action */
     IntegralAction          _exponentialDecayAction;    /** Exponential decay action */
 };

--- a/Common/TsneAnalysis.cpp
+++ b/Common/TsneAnalysis.cpp
@@ -405,6 +405,7 @@ void TsneAnalysis::startComputation(TsneWorker* tsneWorker)
     _workerThread.start();
 
     emit startWorker();
+    emit started();
 }
 
 TsneWorkerTasks::TsneWorkerTasks(QObject* parent, mv::Task* parentTask) :

--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -11,7 +11,6 @@
 
 #include <QThread>
 
-#include <string>
 #include <vector>
 
 class OffscreenBuffer;

--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -69,7 +69,7 @@ private:
 
 private:
     /** Parameters for the execution of the similarity computation and gradient descent */
-    TsneParameters _parameters;
+    TsneParameters _tsneParameters;
 
     /** Parameters for the aknn search */
     KnnParameters _knnParameters;

--- a/Common/TsneAnalysis.h
+++ b/Common/TsneAnalysis.h
@@ -137,6 +137,7 @@ signals:
 
     // Outgoing signals
     void embeddingUpdate(const TsneData tsneData);
+    void started();
     void finished();
     void aborted();
 

--- a/Common/TsneComputationAction.cpp
+++ b/Common/TsneComputationAction.cpp
@@ -1,12 +1,14 @@
 #include "TsneComputationAction.h"
 
+#include "TsneParameters.h"
+
 #include <actions/VerticalGroupAction.h>
 
 #include <QMenu>
 
 using namespace mv::gui;
 
-TsneComputationAction::TsneComputationAction(GroupAction* parent) :
+TsneComputationAction::TsneComputationAction(GroupAction* parent, TsneParameters* tsneParameters) :
     WidgetAction(parent, "TsneComputationAction"),
     _numIterationsAction(this, "New iterations", 1, 10000, 1000),
     _numberOfComputatedIterationsAction(this, "Computed iterations", 0, std::numeric_limits<int>::max(), 0),
@@ -14,7 +16,8 @@ TsneComputationAction::TsneComputationAction(GroupAction* parent) :
     _startComputationAction(this, "Start"),
     _continueComputationAction(this, "Continue"),
     _stopComputationAction(this, "Stop"),
-    _runningAction(this, "Running")
+    _runningAction(this, "Running"),
+    _tsneParameters(tsneParameters)
 {
     _numIterationsAction.setDefaultWidgetFlags(IntegralAction::SpinBox);
     _numberOfComputatedIterationsAction.setDefaultWidgetFlags(IntegralAction::LineEdit);
@@ -28,6 +31,37 @@ TsneComputationAction::TsneComputationAction(GroupAction* parent) :
     _stopComputationAction.setToolTip("Stop the current tSNE computation");
 
     _numberOfComputatedIterationsAction.setEnabled(false);
+
+    if (_tsneParameters)
+    {
+        const auto updateNumIterations = [this]() -> void {
+            _tsneParameters->setExaggerationIter(_numIterationsAction.getValue());
+            };
+
+        connect(&_numIterationsAction, &IntegralAction::valueChanged, this, [this, updateNumIterations](int32_t val) {
+            updateNumIterations();
+            });
+
+        const auto updateUpdateIterations = [this]() -> void {
+            _tsneParameters->setUpdateCore(_updateIterationsAction.getValue());
+            };
+
+        connect(&_updateIterationsAction, &IntegralAction::valueChanged, this, [this, updateUpdateIterations](int32_t val) {
+            updateUpdateIterations();
+            });
+
+        updateNumIterations();
+        updateUpdateIterations();
+    }
+}
+
+void TsneComputationAction::setReadOnly(bool readonly)
+{
+    _numIterationsAction.setEnabled(readonly);
+    _updateIterationsAction.setEnabled(readonly);
+    _startComputationAction.setEnabled(readonly);
+    _continueComputationAction.setEnabled(readonly);
+    _stopComputationAction.setEnabled(readonly);
 }
 
 void TsneComputationAction::addActions() 

--- a/Common/TsneComputationAction.cpp
+++ b/Common/TsneComputationAction.cpp
@@ -1,32 +1,56 @@
 #include "TsneComputationAction.h"
 
-#include <QHBoxLayout>
+#include <actions/VerticalGroupAction.h>
+
 #include <QMenu>
 
 using namespace mv::gui;
 
-TsneComputationAction::TsneComputationAction(QObject* parent) :
-    VerticalGroupAction(parent, "Computation"),
+TsneComputationAction::TsneComputationAction(GroupAction* parent) :
+    WidgetAction(parent, "TsneComputationAction"),
+    _numIterationsAction(this, "New iterations", 1, 10000, 1000),
+    _numberOfComputatedIterationsAction(this, "Computed iterations", 0, std::numeric_limits<int>::max(), 0),
+    _updateIterationsAction(this, "Core update every", 0, 10000, 10),
     _startComputationAction(this, "Start"),
     _continueComputationAction(this, "Continue"),
     _stopComputationAction(this, "Stop"),
     _runningAction(this, "Running")
 {
-    setShowLabels(false);
-    setDefaultWidgetFlag(GroupAction::NoMargins);
+    _numIterationsAction.setDefaultWidgetFlags(IntegralAction::SpinBox);
+    _numberOfComputatedIterationsAction.setDefaultWidgetFlags(IntegralAction::LineEdit);
+    _updateIterationsAction.setDefaultWidgetFlags(IntegralAction::SpinBox | IntegralAction::Slider);
 
-    addAction(&_startComputationAction);
-    addAction(&_continueComputationAction);
-    addAction(&_stopComputationAction);
-
+    _updateIterationsAction.setToolTip("Update the dataset every x iterations. If set to 0, there will be no intermediate result.");
+    _numIterationsAction.setToolTip("Number of new iterations that will be computed when pressing start or continue.");
+    _numberOfComputatedIterationsAction.setToolTip("Number of iterations that have already been computed.");
     _startComputationAction.setToolTip("Start the tSNE computation");
     _continueComputationAction.setToolTip("Continue with the tSNE computation");
     _stopComputationAction.setToolTip("Stop the current tSNE computation");
+
+    _numberOfComputatedIterationsAction.setEnabled(false);
+}
+
+void TsneComputationAction::addActions() 
+{
+    auto buttonGroup = new VerticalGroupAction(parent(), "Computation");
+    buttonGroup->setShowLabels(false);
+    buttonGroup->setDefaultWidgetFlag(GroupAction::NoMargins);
+
+    auto parentAction = dynamic_cast<GroupAction*>(parent());
+
+    parentAction->addAction(&_numIterationsAction);
+    parentAction->addAction(&_numberOfComputatedIterationsAction);
+
+    buttonGroup->addAction(&_startComputationAction);
+    buttonGroup->addAction(&_continueComputationAction);
+    buttonGroup->addAction(&_stopComputationAction);
+
+    parentAction->addAction(buttonGroup);
 }
 
 QMenu* TsneComputationAction::getContextMenu(QWidget* parent /*= nullptr*/)
 {
-    auto menu = new QMenu(text(), parent);
+    auto menu = new QMenu("t-SNE", parent);
 
     menu->addAction(&_startComputationAction);
     menu->addAction(&_continueComputationAction);
@@ -37,8 +61,11 @@ QMenu* TsneComputationAction::getContextMenu(QWidget* parent /*= nullptr*/)
 
 void TsneComputationAction::fromVariantMap(const QVariantMap& variantMap)
 {
-    GroupAction::fromVariantMap(variantMap);
+    WidgetAction::fromVariantMap(variantMap);
 
+    _numIterationsAction.fromParentVariantMap(variantMap);
+    _numberOfComputatedIterationsAction.fromParentVariantMap(variantMap);
+    _updateIterationsAction.fromParentVariantMap(variantMap);
     _startComputationAction.fromParentVariantMap(variantMap);
     _continueComputationAction.fromParentVariantMap(variantMap);
     _stopComputationAction.fromParentVariantMap(variantMap);
@@ -47,8 +74,11 @@ void TsneComputationAction::fromVariantMap(const QVariantMap& variantMap)
 
 QVariantMap TsneComputationAction::toVariantMap() const
 {
-    QVariantMap variantMap = GroupAction::toVariantMap();
+    QVariantMap variantMap = WidgetAction::toVariantMap();
 
+    _numIterationsAction.insertIntoVariantMap(variantMap);
+    _numberOfComputatedIterationsAction.insertIntoVariantMap(variantMap);
+    _updateIterationsAction.insertIntoVariantMap(variantMap);
     _startComputationAction.insertIntoVariantMap(variantMap);
     _continueComputationAction.insertIntoVariantMap(variantMap);
     _stopComputationAction.insertIntoVariantMap(variantMap);

--- a/Common/TsneComputationAction.h
+++ b/Common/TsneComputationAction.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <actions/GroupAction.h>
+#include <actions/IntegralAction.h>
 #include <actions/ToggleAction.h>
 #include <actions/TriggerAction.h>
-#include <actions/VerticalGroupAction.h>
 
 using namespace mv::gui;
 
-class TsneSettingsAction;
 class QMenu;
 
 /**
@@ -16,7 +16,7 @@ class QMenu;
  *
  * @author Thomas Kroes
  */
-class TsneComputationAction : public VerticalGroupAction
+class TsneComputationAction : public WidgetAction
 {
 public:
 
@@ -24,7 +24,7 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      */
-    TsneComputationAction(QObject* parent);
+    TsneComputationAction(GroupAction* parent);
 
     /**
      * Get the context menu for the action
@@ -33,8 +33,16 @@ public:
      */
     QMenu* getContextMenu(QWidget* parent = nullptr) override;
 
+    /**
+     * Add member action to parent
+     */
+    void addActions();
+
 public: // Action getters
 
+    IntegralAction& getNumIterationsAction() { return _numIterationsAction; };
+    IntegralAction& getNumberOfComputatedIterationsAction() { return _numberOfComputatedIterationsAction; };
+    IntegralAction& getUpdateIterationsAction() { return _updateIterationsAction; };
     TriggerAction& getStartComputationAction() { return _startComputationAction; }
     TriggerAction& getContinueComputationAction() { return _continueComputationAction; }
     TriggerAction& getStopComputationAction() { return _stopComputationAction; }
@@ -54,9 +62,14 @@ public: // Serialization
      */
     QVariantMap toVariantMap() const override;
 
-protected:
-    TriggerAction   _startComputationAction;        /** Start computation action */
-    TriggerAction   _continueComputationAction;     /** Continue computation action */
-    TriggerAction   _stopComputationAction;         /** Stop computation action */
-    ToggleAction    _runningAction;                 /** Running action */
+private:
+    IntegralAction          _numIterationsAction;                   /** Number of iterations action */
+    IntegralAction          _numberOfComputatedIterationsAction;    /** Number of computed iterations action */
+    IntegralAction          _updateIterationsAction;                /** Number of update iterations (copying embedding to ManiVault core) */
+
+    TriggerAction           _startComputationAction;                /** Start computation action */
+    TriggerAction           _continueComputationAction;             /** Continue computation action */
+    TriggerAction           _stopComputationAction;                 /** Stop computation action */
+
+    ToggleAction            _runningAction;                         /** Running action */
 };

--- a/Common/TsneComputationAction.h
+++ b/Common/TsneComputationAction.h
@@ -8,6 +8,7 @@
 using namespace mv::gui;
 
 class QMenu;
+class TsneParameters;
 
 /**
  * TSNE computation action class
@@ -24,7 +25,7 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      */
-    TsneComputationAction(GroupAction* parent);
+    TsneComputationAction(GroupAction* parent, TsneParameters* tsneParameters = nullptr);
 
     /**
      * Get the context menu for the action
@@ -37,6 +38,8 @@ public:
      * Add member action to parent
      */
     void addActions();
+
+    void setReadOnly(bool readonly);
 
 public: // Action getters
 
@@ -72,4 +75,6 @@ private:
     TriggerAction           _stopComputationAction;                 /** Stop computation action */
 
     ToggleAction            _runningAction;                         /** Running action */
+
+    TsneParameters*         _tsneParameters;                        /** Pointer to tSNE parameters */
 };

--- a/HSNE/src/GeneralHsneSettingsAction.cpp
+++ b/HSNE/src/GeneralHsneSettingsAction.cpp
@@ -74,8 +74,10 @@ GeneralHsneSettingsAction::GeneralHsneSettingsAction(HsneSettingsAction& hsneSet
         const auto enabled = !isReadOnly();
 
         _knnAlgorithmAction.setEnabled(enabled);
+        _distanceMetricAction.setEnabled(enabled);
         _numScalesAction.setEnabled(enabled);
         _numKnnAction.setEnabled(enabled);
+        _startAction.setEnabled(enabled);
     };
 
     connect(&_knnAlgorithmAction, &OptionAction::currentIndexChanged, this, [this, updateKnnAlgorithm]() {

--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -93,7 +93,6 @@ void HsneAnalysisPlugin::init()
     const auto updateComputationAction = [this, &computationAction]() {
         const auto isRunning = computationAction.getRunningAction().isChecked();
 
-        //computationAction.setReadOnly(false);
         computationAction.getStartComputationAction().setEnabled(!isRunning);
         computationAction.getContinueComputationAction().setEnabled(!isRunning && _tsneAnalysis.canContinue());
         computationAction.getStopComputationAction().setEnabled(isRunning);

--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -93,7 +93,7 @@ void HsneAnalysisPlugin::init()
     const auto updateComputationAction = [this, &computationAction]() {
         const auto isRunning = computationAction.getRunningAction().isChecked();
 
-        computationAction.setReadOnly(false);
+        //computationAction.setReadOnly(false);
         computationAction.getStartComputationAction().setEnabled(!isRunning);
         computationAction.getContinueComputationAction().setEnabled(!isRunning && _tsneAnalysis.canContinue());
         computationAction.getStopComputationAction().setEnabled(isRunning);

--- a/HSNE/src/HsneHierarchy.cpp
+++ b/HSNE/src/HsneHierarchy.cpp
@@ -317,6 +317,8 @@ void HsneHierarchy::saveCacheParameters(std::string fileName, const Hsne::Parame
 
     parameters["Nr. Checks in AKNN"] = internalParams._aknn_num_checks;
     parameters["Nr. Trees for AKNN"] = internalParams._aknn_num_trees;
+    parameters["HNSW Param 1"] = internalParams._aknn_algorithmP1;
+    parameters["HNSW Param 2"] = internalParams._aknn_algorithmP2;
 
     parameters["Memory preserving computation"] = internalParams._out_of_core_computation;
     parameters["Nr. RW for influence"] = internalParams._num_walks_per_landmark;
@@ -457,7 +459,7 @@ bool HsneHierarchy::checkCacheParameters(const std::string fileName, const Hsne:
 
     // if current setting is different from params on disk, don't load from disk
     auto checkParam = [&parameters](std::string paramName, auto localParam) -> bool {
-        auto storedParam = parameters[paramName];
+        auto& storedParam = parameters[paramName];
         if (storedParam != localParam)
         {
             std::ostringstream localParamSS, storedParamSS;
@@ -477,19 +479,21 @@ bool HsneHierarchy::checkCacheParameters(const std::string fileName, const Hsne:
 
     if (!checkParam("Knn library", params._aknn_algorithm)) return false;
     if (!checkParam("Knn distance metric", params._aknn_metric)) return false;
-    //if (!checkParam("Knn number of neighbors", params._num_neighbors)) return false;
+    if (!checkParam("Knn number of neighbors", params._num_neighbors)) return false;
 
-    //if (!checkParam("Nr. Checks in AKNN", params._aknn_num_checks)) return false;
-    //if (!checkParam("Nr. Trees for AKNN", params._aknn_num_trees)) return false;
+    if (!checkParam("Nr. Checks in AKNN", params._aknn_num_checks)) return false;
+    if (!checkParam("Nr. Trees for AKNN", params._aknn_num_trees)) return false;
+    if (!checkParam("HNSW Param 1", params._aknn_num_checks)) return false;
+    if (!checkParam("HNSW Param 2", params._aknn_num_trees)) return false;
 
-    //if (!checkParam("Memory preserving computation", params._out_of_core_computation)) return false;
-    //if (!checkParam("Nr. RW for influence", params._num_walks_per_landmark)) return false;
-    //if (!checkParam("Nr. RW for Monte Carlo", params._mcmcs_num_walks)) return false;
-    //if (!checkParam("Random walks threshold", params._mcmcs_landmark_thresh)) return false;
-    //if (!checkParam("Random walks length", params._mcmcs_walk_length)) return false;
-    //if (!checkParam("Pruning threshold", params._transition_matrix_prune_thresh)) return false;
-    //if (!checkParam("Fixed Percentile Landmark Selection", params._hard_cut_off)) return false;
-    //if (!checkParam("Percentile Landmark Selection", params._hard_cut_off_percentage)) return false;
+    if (!checkParam("Memory preserving computation", params._out_of_core_computation)) return false;
+    if (!checkParam("Nr. RW for influence", params._num_walks_per_landmark)) return false;
+    if (!checkParam("Nr. RW for Monte Carlo", params._mcmcs_num_walks)) return false;
+    if (!checkParam("Random walks threshold", params._mcmcs_landmark_thresh)) return false;
+    if (!checkParam("Random walks length", params._mcmcs_walk_length)) return false;
+    if (!checkParam("Pruning threshold", params._transition_matrix_prune_thresh)) return false;
+    if (!checkParam("Fixed Percentile Landmark Selection", params._hard_cut_off)) return false;
+    if (!checkParam("Percentile Landmark Selection", params._hard_cut_off_percentage)) return false;
 
     if (!checkParam("Seed for random algorithms", params._seed)) return false;
     if (!checkParam("Select landmarks with a MCMCS", params._monte_carlo_sampling)) return false;

--- a/HSNE/src/HsneHierarchy.cpp
+++ b/HSNE/src/HsneHierarchy.cpp
@@ -483,8 +483,8 @@ bool HsneHierarchy::checkCacheParameters(const std::string fileName, const Hsne:
 
     if (!checkParam("Nr. Checks in AKNN", params._aknn_num_checks)) return false;
     if (!checkParam("Nr. Trees for AKNN", params._aknn_num_trees)) return false;
-    if (!checkParam("HNSW Param 1", params._aknn_num_checks)) return false;
-    if (!checkParam("HNSW Param 2", params._aknn_num_trees)) return false;
+    if (!checkParam("HNSW Param 1", params._aknn_algorithmP1)) return false;
+    if (!checkParam("HNSW Param 2", params._aknn_algorithmP2)) return false;
 
     if (!checkParam("Memory preserving computation", params._out_of_core_computation)) return false;
     if (!checkParam("Nr. RW for influence", params._num_walks_per_landmark)) return false;

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -193,7 +193,7 @@ void HsneScaleAction::initNonTopScale(const std::vector<uint32_t>& drillIndices)
 
     // Updates exxageration and exponential decay in _tsneParameters
     _gdAction = new GradientDescentSettingsAction(this, _tsneParameters);
-    addAction(_gdAction);
+    _embedding->addAction(*_gdAction);
 }
 
 void HsneScaleAction::refine()

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -1,9 +1,9 @@
 #include "HsneScaleAction.h"
 
 #include "DataHierarchyItem.h"
+#include "GradientDescentSettingsAction.h"
 #include "HsneHierarchy.h"
 #include "TsneParameters.h"
-#include "GradientDescentSettingsAction.h"
 
 #include <event/Event.h>
 
@@ -420,18 +420,23 @@ void HsneScaleAction::fromVariantMap(const QVariantMap& variantMap)
     _refineAction.fromParentVariantMap(variantMap);
     _computationAction.fromParentVariantMap(variantMap);
 
+    // Handle _tsneParameters
+    _tsneParameters.setNumIterations(variantMap["NumIterations"].toInt());
+    _tsneParameters.setExaggerationIter(variantMap["ExaggerationIter"].toInt());
+    _tsneParameters.setExponentialDecayIter(variantMap["ExponentialDecayIter"].toInt());
+    _tsneParameters.setNumDimensionsOutput(variantMap["NumDimensionsOutput"].toInt());
+    _tsneParameters.setUpdateCore(variantMap["UpdateCore"].toInt());
 }
 
 QVariantMap HsneScaleAction::toVariantMap() const
 {
     QVariantMap variantMap = GroupAction::toVariantMap();
 
-    _refineAction.insertIntoVariantMap(variantMap);
-    _computationAction.insertIntoVariantMap(variantMap);
-
-    variantMap["inputGUID"] = QVariant::fromValue(_input.get<Points>()->getId());
+    // Handle data sets
+    variantMap["inputGUID"]     = QVariant::fromValue(_input.get<Points>()->getId());
     variantMap["embeddingGUID"] = QVariant::fromValue(_embedding.get<Points>()->getId());
     
+    // Handle refined datasets and corresponding actions
     QVariantMap refinedEmbeddingsMap;
 
     assert(_refineEmbeddings.size() == _refinedScaledActions.size());
@@ -452,12 +457,23 @@ QVariantMap HsneScaleAction::toVariantMap() const
         refinedEmbeddingsMap[QString::number(i)] = refinedEmbeddingMap;
     }
 
-    variantMap["refinedEmbeddingsMap"] = refinedEmbeddingsMap;
+    variantMap["refinedEmbeddingsMap"]  = refinedEmbeddingsMap;
 
-    variantMap["drillIndices"] = rawDataToVariantMap((char*)_drillIndices.data(), _drillIndices.size() * sizeof(uint32_t), true);
-    variantMap["drillIndicesSize"] = QVariant::fromValue(_drillIndices.size());
-    variantMap["isTopScale"] = QVariant::fromValue(_isTopScale);
-    variantMap["currentScaleLevel"] = QVariant::fromValue(_currentScaleLevel);
+    // Handle own data
+    variantMap["drillIndices"]          = rawDataToVariantMap((char*)_drillIndices.data(), _drillIndices.size() * sizeof(uint32_t), true);
+    variantMap["drillIndicesSize"]      = QVariant::fromValue(_drillIndices.size());
+    variantMap["isTopScale"]            = QVariant::fromValue(_isTopScale);
+    variantMap["currentScaleLevel"]     = QVariant::fromValue(_currentScaleLevel);
+
+    _refineAction.insertIntoVariantMap(variantMap);
+    _computationAction.insertIntoVariantMap(variantMap);
+
+    // Handle _tsneParameters
+    variantMap["NumIterations"]         = QVariant::fromValue(_tsneParameters.getNumIterations());
+    variantMap["ExaggerationIter"]      = QVariant::fromValue(_tsneParameters.getExaggerationIter());
+    variantMap["ExponentialDecayIter"]  = QVariant::fromValue(_tsneParameters.getExponentialDecayIter());
+    variantMap["NumDimensionsOutput"]   = QVariant::fromValue(_tsneParameters.getNumDimensionsOutput());
+    variantMap["UpdateCore"]            = QVariant::fromValue(_tsneParameters.getUpdateCore());
 
     return variantMap;
 }

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -392,27 +392,17 @@ void HsneScaleAction::fromVariantMap(const QVariantMap& variantMap)
         {
             _refineEmbeddings.push_back(refineEmbedding);
 
-            if (refinedEmbeddingMap["refinedCurrentScaleLevel"].toUInt() > 0)
-            {
-                _refinedScaledActions.push_back(new HsneScaleAction(this, _hsneHierarchy, _input, refineEmbedding, refinedEmbeddingMap["refinedCurrentScaleLevel"].toUInt()));
-                HsneScaleAction* refinedScaledAction = _refinedScaledActions.back();
+            _refinedScaledActions.push_back(new HsneScaleAction(this, _hsneHierarchy, _input, refineEmbedding, refinedEmbeddingMap["refinedCurrentScaleLevel"].toUInt()));
+            HsneScaleAction* refinedScaledAction = _refinedScaledActions.back();
 
-                const auto refinedDrillIndices = refinedEmbeddingMap["refinedDrillIndices"].toMap();
-                std::vector<uint32_t> refinedDrillIndicesVec;
-                refinedDrillIndicesVec.resize(static_cast<size_t>(refinedEmbeddingMap["refinedDrillIndicesSize"].toInt()));
-                populateDataBufferFromVariantMap(refinedDrillIndices, (char*)refinedDrillIndicesVec.data());
-                refinedScaledAction->initNonTopScale(std::move(refinedDrillIndicesVec));
+            const auto refinedDrillIndices = refinedEmbeddingMap["refinedDrillIndices"].toMap();
+            std::vector<uint32_t> refinedDrillIndicesVec;
+            refinedDrillIndicesVec.resize(static_cast<size_t>(refinedEmbeddingMap["refinedDrillIndicesSize"].toInt()));
+            populateDataBufferFromVariantMap(refinedDrillIndices, (char*)refinedDrillIndicesVec.data());
+            refinedScaledAction->initNonTopScale(std::move(refinedDrillIndicesVec));
 
-                refineEmbedding->addAction(*refinedScaledAction);
-                refineEmbedding->_infoAction->collapse();
-            }
-            else
-            {
-                _refinedScaledActions.push_back(nullptr);
-                //auto refinedComputeAction = new TsneComputationAction(this);
-                //refineEmbedding->addAction(*refinedComputeAction);
-            }
-
+            refineEmbedding->addAction(*refinedScaledAction);
+            refineEmbedding->_infoAction->collapse();
         }
     }
     assert(_refineEmbeddings.size() == _refinedScaledActions.size());
@@ -453,18 +443,12 @@ QVariantMap HsneScaleAction::toVariantMap() const
 
         QVariantMap refinedEmbeddingMap;
 
-        if (refineEmbedding.isValid() )
+        if (refineEmbedding.isValid() && refinedScaledAction != nullptr)
         {
-            refinedEmbeddingMap["refineEmbeddingGUID"] = QVariant::fromValue(refineEmbedding.get<Points>()->getId());
-
-            if (refinedScaledAction != nullptr)
-            {
-                refinedEmbeddingMap["refinedDrillIndices"] = rawDataToVariantMap((char*)refinedScaledAction->_drillIndices.data(), refinedScaledAction->_drillIndices.size() * sizeof(uint32_t), true);
-                refinedEmbeddingMap["refinedDrillIndicesSize"] = QVariant::fromValue(refinedScaledAction->_drillIndices.size());
-                refinedEmbeddingMap["refinedCurrentScaleLevel"] = QVariant::fromValue(refinedScaledAction->_currentScaleLevel);
-            }
-            else
-                refinedEmbeddingMap["refinedCurrentScaleLevel"] = QVariant::fromValue(0);
+            refinedEmbeddingMap["refineEmbeddingGUID"]      = QVariant::fromValue(refineEmbedding.get<Points>()->getId());
+            refinedEmbeddingMap["refinedDrillIndices"]      = rawDataToVariantMap((char*)refinedScaledAction->_drillIndices.data(), refinedScaledAction->_drillIndices.size() * sizeof(uint32_t), true);
+            refinedEmbeddingMap["refinedDrillIndicesSize"]  = QVariant::fromValue(refinedScaledAction->_drillIndices.size());
+            refinedEmbeddingMap["refinedCurrentScaleLevel"] = QVariant::fromValue(refinedScaledAction->_currentScaleLevel);
         }
 
         refinedEmbeddingsMap[QString::number(i)] = refinedEmbeddingMap;

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -176,23 +176,23 @@ void HsneScaleAction::initLayoutAndConnection()
         if (dataEvent->getType() == EventType::DatasetDataSelectionChanged && removedDataID == _embedding->getId())
             updateReadOnly();
 
-        // Remove invisible selection helper dataset when scale dataset is removed
-        if (dataEvent->getType() == EventType::DatasetAboutToBeRemoved && removedData->hasProperty("selectionHelperID"))
-        {
-            const auto& selectionHelperID = removedData->getProperty("selectionHelperID").toString();
+        //// Remove invisible selection helper dataset when scale dataset is removed
+        //if (dataEvent->getType() == EventType::DatasetAboutToBeRemoved && removedData->hasProperty("selectionHelperID"))
+        //{
+        //    const auto& selectionHelperID = removedData->getProperty("selectionHelperID").toString();
 
-            // Check if the removed dataset was a selection helper created by this scale
-            auto wasCreatedByScale = [&selectionHelperID](Dataset<DatasetImpl> s) { return s->getId() == selectionHelperID; };
-            if (auto it = std::find_if(std::begin(_selectionHelpers), std::end(_selectionHelpers), wasCreatedByScale); it != std::end(_selectionHelpers))
-            {
-                if ((*it).isValid())
-                {
-                    qDebug() << "HSNE Scale: remove (invisible) selection helper dataset " << (*it)->getId() << " used for deleted " << removedDataID;
-                    //mv::data().removeDataset(*it);
-                }
-                _selectionHelpers.erase(it);
-            }
-        }
+        //    // Check if the removed dataset was a selection helper created by this scale
+        //    auto wasCreatedByScale = [&selectionHelperID](Dataset<DatasetImpl> s) { return s->getId() == selectionHelperID; };
+        //    if (auto it = std::find_if(std::begin(_selectionHelpers), std::end(_selectionHelpers), wasCreatedByScale); it != std::end(_selectionHelpers))
+        //    {
+        //        if ((*it).isValid())
+        //        {
+        //            qDebug() << "HSNE Scale: remove (invisible) selection helper dataset " << (*it)->getId() << " used for deleted " << removedDataID;
+        //            mv::data().removeDataset(*it);
+        //        }
+        //        _selectionHelpers.erase(it);
+        //    }
+        //}
 
     });
 
@@ -300,6 +300,8 @@ void HsneScaleAction::refine()
         _refineEmbeddings.push_back(mv::data().createDerivedDataset<Points>(QString("Hsne scale %1").arg(refinedScaleLevel), hsneScaleSubset, _embedding));
         auto& refineEmbedding = _refineEmbeddings.back();
         refineEmbedding->setProperty("selectionHelperID", hsneScaleSubset->getId());
+
+        //qDebug() << "refineEmbedding " << refineEmbedding->getId() << " with hsneScaleSubset " << hsneScaleSubset->getId();
 
         refineEmbedding->setData(nullptr, 0, 2);
         events().notifyDatasetDataChanged(refineEmbedding);

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -35,8 +35,7 @@ HsneScaleAction::HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, 
     _initializationTask(this, "Preparing HSNE scale"),
     _isTopScale(true),
     _currentScaleLevel(1),
-    _tsneParametersTopLevel(nullptr),
-    _tsneAnalysisDataLevel()
+    _tsneParametersTopLevel(nullptr)
 {
 }
 

--- a/HSNE/src/HsneScaleAction.cpp
+++ b/HSNE/src/HsneScaleAction.cpp
@@ -35,7 +35,6 @@ HsneScaleAction::HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, 
     _initializationTask(this, "Preparing HSNE scale"),
     _isTopScale(true),
     _currentScaleLevel(1),
-    _gdAction(nullptr),
     _tsneParametersTopLevel(nullptr),
     _tsneAnalysisDataLevel()
 {
@@ -192,8 +191,8 @@ void HsneScaleAction::initNonTopScale(const std::vector<uint32_t>& drillIndices)
     _isTopScale = false;
 
     // Updates exxageration and exponential decay in _tsneParameters
-    _gdAction = new GradientDescentSettingsAction(this, _tsneParameters);
-    _embedding->addAction(*_gdAction);
+    auto gradDescentAction = new GradientDescentSettingsAction(this, _tsneParameters);
+    _embedding->addAction(*gradDescentAction);
 }
 
 void HsneScaleAction::refine()

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -12,8 +12,6 @@
 
 #include "PointData/PointData.h"
 
-#include <memory>
-
 using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -121,6 +121,4 @@ protected:
     std::vector<uint32_t>   _drillIndices;          /** Vector relating local indices to scale relative indices */
     bool                    _isTopScale;            /** Whether current scale is the top scale */
     unsigned int            _currentScaleLevel;     /** The scale the current embedding is a part of */
-
-    friend class HsneScaleAction;
 };

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -93,6 +93,7 @@ public: // Serialization
 
 private:
     using Datasets              = std::vector<Dataset<Points>>;
+    using DatasetImpls          = std::vector<Dataset<DatasetImpl>>;
     using RefineScaleActions    = std::vector<HsneScaleAction*>;
 
 private:
@@ -102,6 +103,7 @@ private:
     Dataset<Points>         _input;                 /** Input dataset reference */
     Dataset<Points>         _embedding;             /** Embedding dataset reference */
     Datasets                _refineEmbeddings;      /** Refine embedding dataset references */
+    DatasetImpls            _selectionHelpers;      /** References to selection helper datasets */
 
     TsneParameters*         _tsneParametersTopLevel;        /** TSNE paremeters from the top level HSNE analysis */
 

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -92,9 +92,8 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 private:
-    using Datasets = std::vector<Dataset<Points>>;
-    using RefineScaleActions = std::vector<HsneScaleAction*>;
-    using DataComputeActions = std::vector<TsneComputationAction*>;
+    using Datasets              = std::vector<Dataset<Points>>;
+    using RefineScaleActions    = std::vector<HsneScaleAction*>;
 
 private:
     TsneParameters          _tsneParameters;        /** TSNE paremeters */

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -12,8 +12,6 @@
 
 #include "PointData/PointData.h"
 
-#include <memory>
-
 using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;
@@ -107,7 +105,6 @@ private:
     Datasets                _refineEmbeddings;      /** Refine embedding dataset references */
 
     TsneParameters*         _tsneParametersTopLevel;        /** TSNE paremeters from the top level HSNE analysis */
-    std::unique_ptr<TsneAnalysis> _tsneAnalysisDataLevel;   /** data level t-SNE Analysis */
 
 private:
     TriggerAction           _refineAction;          /** Refine action */

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -63,9 +63,8 @@ private:
 public: // Action getters
 
     TriggerAction& getRefineAction() { return _refineAction; }
-    IntegralAction& getNumIterationsAction() { return _numIterationsAction; };
-    IntegralAction& getNumberOfComputatedIterationsAction() { return _numberOfComputatedIterationsAction; };
     TsneComputationAction& getComputationAction() { return _computationAction; }
+    IntegralAction& getNumberOfComputatedIterationsAction() { return _computationAction.getNumberOfComputatedIterationsAction(); };
 
 public: // Setters
     void setScale(unsigned int scale)
@@ -107,9 +106,6 @@ private:
 
 private:
     TriggerAction           _refineAction;                          /** Refine action */
-    IntegralAction          _numIterationsAction;                   /** Number of iterations action */
-    IntegralAction          _numberOfComputatedIterationsAction;    /** Number of computed iterations action */
-    IntegralAction          _updateIterationsAction;                /** Number of update iterations (copying embedding to ManiVault core) */
     TsneComputationAction   _computationAction;                     /** Computation action */
 
     EventListener           _eventListener;         /** Listen to HDPS events */

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -23,7 +23,6 @@ class QMenu;
 class HsneAnalysisPlugin;
 class HsneHierarchy;
 class TsneParameters;
-class GradientDescentSettingsAction;
 
 namespace mv {
     class CoreInterface;
@@ -113,7 +112,6 @@ private:
 private:
     TriggerAction           _refineAction;          /** Refine action */
     TsneComputationAction   _computationAction;     /** Computation action */
-    GradientDescentSettingsAction* _gdAction;
 
     EventListener           _eventListener;         /** Listen to HDPS events */
     mv::ForegroundTask      _initializationTask;    /** Task for reporting computation preparation progress */

--- a/HSNE/src/HsneScaleAction.h
+++ b/HSNE/src/HsneScaleAction.h
@@ -43,12 +43,14 @@ public:
     /**
      * Constructor
      * @param parent Pointer to parent object
-     * @param tsneSettingsAction Reference to TSNE settings action
      * @param hsneHierarchy Reference to HSNE hierarchy
      * @param inputDataset Smart pointer to input dataset
      * @param embeddingDataset Smart pointer to embedding dataset
      */
-    HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, Dataset<Points> inputDataset, Dataset<Points> embeddingDataset, TsneParameters* tsneParametersTopLevel = nullptr);
+    HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, Dataset<Points> inputDataset, Dataset<Points> embeddingDataset);
+
+    HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, Dataset<Points> inputDataset, Dataset<Points> embeddingDataset, TsneParameters* tsneParametersTopLevel);
+    HsneScaleAction(QObject* parent, HsneHierarchy& hsneHierarchy, Dataset<Points> inputDataset, Dataset<Points> embeddingDataset, unsigned int scale);
 
     ~HsneScaleAction();
 
@@ -62,6 +64,9 @@ public:
 private:
     /** Refine the landmarks based on the current selection */
     void refine();
+
+    /** Add actions to GUI and connect them */
+    void initLayoutAndConnection();
 
 public: // Action getters
 
@@ -91,7 +96,7 @@ public: // Serialization
 
 private:
     using Datasets = std::vector<Dataset<Points>>;
-    using RefineActions = std::vector<HsneScaleAction*>;
+    using RefineScaleActions = std::vector<HsneScaleAction*>;
     using DataComputeActions = std::vector<TsneComputationAction*>;
 
 private:
@@ -102,7 +107,8 @@ private:
     Dataset<Points>         _embedding;             /** Embedding dataset reference */
     Datasets                _refineEmbeddings;      /** Refine embedding dataset references */
 
-    TsneParameters*         _tsneParametersTopLevel;    /** TSNE paremeters from the top level HSNE analysis*/
+    TsneParameters*         _tsneParametersTopLevel;        /** TSNE paremeters from the top level HSNE analysis */
+    std::unique_ptr<TsneAnalysis> _tsneAnalysisDataLevel;   /** data level t-SNE Analysis */
 
 private:
     TriggerAction           _refineAction;          /** Refine action */
@@ -112,8 +118,7 @@ private:
     EventListener           _eventListener;         /** Listen to HDPS events */
     mv::ForegroundTask      _initializationTask;    /** Task for reporting computation preparation progress */
 
-    RefineActions           _refinedScaledActions;  /** Scale actions of the refined datasets */
-    DataComputeActions      _dataComputeActions;    /** Compute actions of the data level */
+    RefineScaleActions      _refinedScaledActions;  /** Scale actions of the refined datasets */
 
 protected:
     std::vector<uint32_t>   _drillIndices;          /** Vector relating local indices to scale relative indices */

--- a/HSNE/src/HsneSettingsAction.cpp
+++ b/HSNE/src/HsneSettingsAction.cpp
@@ -14,7 +14,7 @@ HsneSettingsAction::HsneSettingsAction(HsneAnalysisPlugin* hsneAnalysisPlugin) :
     _hierarchyConstructionSettingsAction(*this),
     _gradientDescentSettingsAction(this, _tsneParameters),
     _knnSettingsAction(this, _knnParameters),
-    _topLevelScaleAction(nullptr, _tsneParameters, hsneAnalysisPlugin->getHierarchy(), hsneAnalysisPlugin->getInputDataset<Points>(), hsneAnalysisPlugin->getOutputDataset<Points>())
+    _topLevelScaleAction(this, hsneAnalysisPlugin->getHierarchy(), hsneAnalysisPlugin->getInputDataset<Points>(), hsneAnalysisPlugin->getOutputDataset<Points>(), &_tsneParameters)
 {
     const auto updateReadOnly = [this]() -> void {
         _generalHsneSettingsAction.setReadOnly(isReadOnly());

--- a/tSNE/src/GeneralTsneSettingsAction.h
+++ b/tSNE/src/GeneralTsneSettingsAction.h
@@ -31,8 +31,8 @@ public: // Action getters
     TsneSettingsAction& getTsneSettingsAction() { return _tsneSettingsAction; };
     OptionAction& getKnnAlgorithmAction() { return _knnAlgorithmAction; };
     OptionAction& getDistanceMetricAction() { return _distanceMetricAction; };
-    IntegralAction& getNumIterationsAction() { return _numIterationsAction; };
-    IntegralAction& getNumberOfComputatedIterationsAction() { return _numberOfComputatedIterationsAction; };
+    IntegralAction& getNumIterationsAction() { return _computationAction.getNumIterationsAction(); };
+    IntegralAction& getNumberOfComputatedIterationsAction() { return _computationAction.getNumberOfComputatedIterationsAction(); };
     IntegralAction& getPerplexityAction() { return _perplexityAction; };
     TsneComputationAction& getComputationAction() { return _computationAction; }
 
@@ -54,9 +54,6 @@ protected:
     TsneSettingsAction&     _tsneSettingsAction;                    /** Reference to parent tSNE settings action */
     OptionAction            _knnAlgorithmAction;                    /** KNN algorithm action */
     OptionAction            _distanceMetricAction;                  /** Distance metric action */
-    IntegralAction          _numIterationsAction;                   /** Number of iterations action */
-    IntegralAction          _numberOfComputatedIterationsAction;    /** Number of computed iterations action */
     IntegralAction          _perplexityAction;                      /** Perplexity action */
-    IntegralAction          _updateIterationsAction;                /** Number of update iterations (copying embedding to ManiVault core) */
     TsneComputationAction   _computationAction;                     /** Computation action */
 };


### PR DESCRIPTION
- New: recompute embedding on data scale
- Improved: check more parameters before loading cached HSNE hierarchy
- Fixed: deleting certain scales could lead to a crash
- Fixed: some UI elements were not disabled during computation correctly

This PR also prepares the deletion of invisible selection helper dataset, when a respective scale embedding is deleted. Currently, this confuses the core a little, so these lines will remain commented out for a short while.