### PR TITLE
Fix restarting HSNE

### DIFF
--- a/HSNE/src/CMakeLists.txt
+++ b/HSNE/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HSNE_PLUGIN_SOURCES
     ${DIR}/HsneHierarchy.h
     ${DIR}/HsneHierarchy.cpp
     ${DIR}/HsneParameters.h
+    ${DIR}/HsneRecomputeWarningDialog.h
     PARENT_SCOPE
 )
 

--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -165,6 +165,7 @@ void HsneAnalysisPlugin::init()
         computeTopLevelEmbedding();
 
         _hsneSettingsAction->getGeneralHsneSettingsAction().getStartAction().setText("Recompute");
+        _hsneSettingsAction->getGeneralHsneSettingsAction().getStartAction().setToolTip("Recomputing does not change the selection mapping.\n If the data size changed, prefer creating a new HSNE analysis.");
     });
 
     connect(&_tsneAnalysis, &TsneAnalysis::started, this, [this, &computationAction, updateComputationAction]() {

--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -350,6 +350,8 @@ void HsneAnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
     }
 
     _selectionHelperData = mv::data().getDataset(variantMap["selectionHelperDataGUID"].toString());
+    _hsneSettingsAction->getGeneralHsneSettingsAction().getStartAction().setText("Recompute");
+    _hsneSettingsAction->getGeneralHsneSettingsAction().getStartAction().setToolTip("Recomputing does not change the selection mapping.\n If the data size changed, prefer creating a new HSNE analysis.");
 }
 
 QVariantMap HsneAnalysisPlugin::toVariantMap() const

--- a/HSNE/src/HsneAnalysisPlugin.cpp
+++ b/HSNE/src/HsneAnalysisPlugin.cpp
@@ -1,4 +1,5 @@
 #include "HsneAnalysisPlugin.h"
+
 #include "HsneParameters.h"
 #include "HsneScaleAction.h"
 #include "HsneRecomputeWarningDialog.h"
@@ -140,6 +141,16 @@ void HsneAnalysisPlugin::init()
     });
 
     connect(&_hsneSettingsAction->getGeneralHsneSettingsAction().getStartAction(), &TriggerAction::triggered, this, [this](bool toggled) {
+
+        // Create a warning dialog if there are already refined scales
+        if (_selectionHelperData.isValid() && getOutputDataset<Points>()->getDataHierarchyItem().getChildren().size() > 0)
+        {
+            HsneRecomputeWarningDialog dialog;
+
+            if (dialog.exec() == QDialog::Rejected)
+                return;
+        }
+
         _hsneSettingsAction->setReadOnly(true);
         
         qApp->processEvents();

--- a/HSNE/src/HsneAnalysisPlugin.h
+++ b/HSNE/src/HsneAnalysisPlugin.h
@@ -55,6 +55,7 @@ private:
     HsneHierarchy           _hierarchy;             /** HSNE hierarchy */
     TsneAnalysis            _tsneAnalysis;          /** TSNE analysis */
     HsneSettingsAction*     _hsneSettingsAction;    /** Pointer to HSNE settings action */
+    mv::Dataset<Points>     _selectionHelperData;   /** Invisible selection helper dataset */
     mv::Task                _dataPreparationTask;   /** Task for reporting data preparation progress */
 };
 

--- a/HSNE/src/HsneRecomputeWarningDialog.h
+++ b/HSNE/src/HsneRecomputeWarningDialog.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QDialog>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+class HsneRecomputeWarningDialog : public QDialog
+{
+public:
+    HsneRecomputeWarningDialog() : QDialog()
+    {
+        setWindowTitle("Restarting HSNE");
+
+        QLabel* warnText = new QLabel("The top level HSNE embedding has at least one refined scale.\n Recomputing the analysis might have unintended consequences.");
+        QPushButton* stopButton = new QPushButton("Stop");
+        QPushButton* continueButton = new QPushButton("Continue");
+
+        QObject::connect(continueButton, &QPushButton::clicked, [&]() {
+            accept();
+        });
+
+        QObject::connect(stopButton, &QPushButton::clicked, [&]() {
+            reject();
+        });
+
+        QHBoxLayout* buttonLayout = new QHBoxLayout;
+        buttonLayout->addWidget(stopButton);
+        buttonLayout->addWidget(continueButton);
+
+        QVBoxLayout* layout = new QVBoxLayout;
+        layout->addWidget(warnText);
+        layout->addLayout(buttonLayout);
+
+        setLayout(layout);
+    }
+};


### PR DESCRIPTION
When recomputing an HSNE, the plugin was struggling with the selection mapping until now.

This PR skips the creation of a new selection helper for the top level embedding if it already exists. Now, recomputing the HSNE completely (knn search + random walks + gradient descent) is possible.

Some usage advice to keep in mind: 
- if the input data size changed since we computed an HSNE, instead of recomputing an HSNE you should create a new analysis. Anyways, I think this is a very rare case, but I added a tool tip message about this into the recompute button nonetheless.
- if the top embedding has at least one refined embedding, a warn dialog will ask the user to reconsider recomputing. I think here again it's better to create a new HSNE analysis.

Addresses https://github.com/ManiVaultStudio/t-SNE-Analysis/issues/48