### PR TITLE
Hierachy computation in different thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,15 +53,17 @@ message(STATUS "MV_INSTALL_DIR set to ${MV_INSTALL_DIR}")
 # -----------------------------------------------------------------------------
 # Install dependency libraries
 # -----------------------------------------------------------------------------
-set(HDILib_VERSION 1.2.6)
-set(flann_VERSION 1.9.2)
-set(lz4_VERSION 1.9.3)
 
 set(LIBRARY_INSTALL_DIR ${PROJECT_BINARY_DIR})
 
 include(InstallArtifactoryPackage)
 if (USE_ARTIFACTORY_LIBS AND NOT ARTIFACTORY_LIBS_INSTALLED) 
     message(STATUS "Installing artifactory packages to: ${LIBRARY_INSTALL_DIR}")
+
+    set(HDILib_VERSION 1.2.6)
+    set(flann_VERSION 1.9.2)
+    set(lz4_VERSION 1.9.3)
+
     # Both HDILib and flann are available prebuilt in the lkeb-artifactory as combined Debug/Release packages
     # lz4 is also available in the lkb-artifactory in separate Debug and |Release packages
     install_artifactory_package(HDILib ${HDILib_VERSION} biovault TRUE) 

--- a/src/Common/TsneAnalysis.cpp
+++ b/src/Common/TsneAnalysis.cpp
@@ -189,7 +189,6 @@ void TsneWorker::computeSimilarities()
 {
     assert(_data.size() == _numDimensions * _numPoints);
 
-    //_tasks->getComputingSimilaritiesTask().setEnabled(true);
     _tasks->getComputingSimilaritiesTask().setRunning();
 
     double t = 0.0;

--- a/src/HSNE/HierarchyConstructionSettingsAction.cpp
+++ b/src/HSNE/HierarchyConstructionSettingsAction.cpp
@@ -48,7 +48,7 @@ HierarchyConstructionSettingsAction::HierarchyConstructionSettingsAction(HsneSet
     _useOutOfCoreComputationAction.setToolTip("Use out-of-core computation");
     _useMonteCarloSamplingAction.setToolTip("Use Monte Carlo Sampling");
     _seedAction.setToolTip("Random seed for initialization");
-    _saveHierarchyToDiskAction.setToolTip("Save computed hierarchy to disk. \nWhen computing HSNE again with the same settings, \nthe hierarchy is loaded instead of recomputed");
+    _saveHierarchyToDiskAction.setToolTip("Save (load) computed hierarchy to (from) disk. \nWhen computing HSNE again with the same settings, \nthe hierarchy is loaded instead of recomputed");
     _saveHierarchyToProjectAction.setToolTip("Save computed hierarchy when saving a project. \nThis enables selection refinements \nafter loading projects");
 
     const auto& hsneParameters = hsneSettingsAction.getHsneParameters();

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -152,6 +152,7 @@ void HsneAnalysisPlugin::init()
         
         _hsneSettingsAction->getGeneralHsneSettingsAction().setReadOnly(false);
         _hsneSettingsAction->getHierarchyConstructionSettingsAction().setReadOnly(false);
+        _hsneSettingsAction->getTopLevelScaleAction().setReadOnly(false);
         _hsneSettingsAction->getGradientDescentSettingsAction().setReadOnly(false);
         _hsneSettingsAction->getKnnSettingsAction().setReadOnly(false);
 

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -37,6 +37,9 @@ HsneAnalysisPlugin::HsneAnalysisPlugin(const PluginFactory* factory) :
 
 HsneAnalysisPlugin::~HsneAnalysisPlugin()
 {
+    _hierarchyThread.quit();           // Signal the thread to quit gracefully
+    if (!_hierarchyThread.wait(500))   // Wait for the thread to actually finish
+        _hierarchyThread.terminate();  // Terminate thread after 0.5 seconds
 }
 
 void HsneAnalysisPlugin::init()

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -231,7 +231,7 @@ void HsneAnalysisPlugin::init()
 
     auto& datasetTask = outputDataset->getTask();
 
-    datasetTask.setName("Compute HSNE");
+    datasetTask.setName("Compute HSNE top level embedding");
     datasetTask.setConfigurationFlag(Task::ConfigurationFlag::OverrideAggregateStatus);
 
     _tsneAnalysis.setTask(&datasetTask);

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -185,7 +185,7 @@ void HsneAnalysisPlugin::init()
         // Initialize the HSNE algorithm with the given parameters and compute the hierarchy
         auto inputData      = getInputDataset<Points>();
         std::vector<bool> enabledDimensions = inputData->getDimensionsPickerAction().getEnabledDimensions();
-        _hierarchy->setDataAndParameters(inputData, std::move(enabledDimensions), _hsneSettingsAction->getHsneParameters(), _hsneSettingsAction->getKnnParameters());
+        _hierarchy->setDataAndParameters(inputData, getOutputDataset<Points>(), _hsneSettingsAction->getHsneParameters(), _hsneSettingsAction->getKnnParameters(), std::move(enabledDimensions));
         
         _hierarchy->moveToThread(&_hierarchyThread);
 
@@ -360,7 +360,7 @@ void HsneAnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
     _hsneSettingsAction->fromVariantMap(variantMap["HSNE Settings"].toMap());
 
     std::vector<bool> enabledDimensions = getInputDataset<Points>()->getDimensionsPickerAction().getEnabledDimensions();
-    _hierarchy->setDataAndParameters(*getInputDataset<Points>(), std::move(enabledDimensions), _hsneSettingsAction->getHsneParameters(), _hsneSettingsAction->getKnnParameters());
+    _hierarchy->setDataAndParameters(getInputDataset<Points>(), getOutputDataset<Points>(), _hsneSettingsAction->getHsneParameters(), _hsneSettingsAction->getKnnParameters(), std::move(enabledDimensions));
 
     auto& hsne = _hierarchy->getHsne();
     hsne.setDimensionality(_hierarchy->getNumDimensions());

--- a/src/HSNE/HsneAnalysisPlugin.h
+++ b/src/HSNE/HsneAnalysisPlugin.h
@@ -2,8 +2,6 @@
 
 #include <AnalysisPlugin.h>
 
-#include <Task.h>
-
 #include <event/EventListener.h>
 
 #include "HsneHierarchy.h"
@@ -64,7 +62,6 @@ private:
     HsneSettingsAction*     _hsneSettingsAction;    /** Pointer to HSNE settings action */
     EventListener           _eventListener;         /** Listen to ManiVault events */
     mv::Dataset<Points>     _selectionHelperData;   /** Invisible selection helper dataset */
-    mv::Task                _dataPreparationTask;   /** Task for reporting data preparation progress */
 };
 
 class HsneAnalysisPluginFactory : public AnalysisPluginFactory

--- a/src/HSNE/HsneAnalysisPlugin.h
+++ b/src/HSNE/HsneAnalysisPlugin.h
@@ -34,7 +34,7 @@ public:
     void computeTopLevelEmbedding();
     void continueComputation();
 
-    HsneHierarchy& getHierarchy() { return _hierarchy; }
+    HsneHierarchy& getHierarchy() { return *_hierarchy.get(); }
     TsneAnalysis& getTsneAnalysis() { return _tsneAnalysis; }
 
     HsneSettingsAction& getHsneSettingsAction() { return *_hsneSettingsAction; }
@@ -53,8 +53,13 @@ public: // Serialization
      */
     Q_INVOKABLE QVariantMap toVariantMap() const override;
 
+signals:
+    // Local signals
+    void startHierarchyWorker();
+
 private:
-    HsneHierarchy           _hierarchy;             /** HSNE hierarchy */
+    std::unique_ptr<HsneHierarchy> _hierarchy;      /** HSNE hierarchy */
+    QThread                 _hierarchyThread;       /** Qt Thread for managing HSNE hierarchy computation */
     TsneAnalysis            _tsneAnalysis;          /** TSNE analysis */
     HsneSettingsAction*     _hsneSettingsAction;    /** Pointer to HSNE settings action */
     EventListener           _eventListener;         /** Listen to ManiVault events */

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -189,7 +189,7 @@ void HsneHierarchy::setDataAndParameters(const mv::Dataset<Points>& inputData, c
 
 void HsneHierarchy::initialize()
 {
-    assert(_inputData->isValid());
+    assert(_inputData.isValid());
 
     hdi::utils::CoutLog log;
 

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -204,6 +204,11 @@ void HsneHierarchy::initialize()
         // Set the dimensionality of the data in the HSNE object
         _hsne->setDimensionality(_numDimensions);
 
+        auto& datasetTask = _inputData->getTask();
+        datasetTask.setName("Initialize HSNE hierachy");
+        datasetTask.setRunning();
+        datasetTask.setProgress(.0f);
+
         // Load data and enabled dimensions
         std::vector<float> data;
         std::vector<unsigned int> dimensionIndices;
@@ -216,16 +221,24 @@ void HsneHierarchy::initialize()
         // Initialize HSNE with the input data and the given parameters
         _hsne->initialize((Hsne::scalar_type*)data.data(), _numPoints, _params);
 
+        datasetTask.setProgress(.33f);
+
         // Add a number of scales as indicated by the user
         for (int s = 0; s < _numScales - 1; ++s) {
             _hsne->addScale();
         }
 
+        datasetTask.setProgress(.66f);
+
         _influenceHierarchy.initialize(*this);
+
+        datasetTask.setProgress(.9f);
 
         // Write HSNE hierarchy to disk
         if(parameters.getSaveHierarchyToDisk())
             saveCacheHsne(_params); 
+
+        datasetTask.setFinished();
     }
 
     _isInit = true;

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -136,7 +136,7 @@ void HsneHierarchy::printScaleInfo() const
     std::cout << "AoI size: " << _hsne->scale(getNumScales() - 1)._area_of_influence.size() << std::endl;
 }
 
-void HsneHierarchy::setDataAndParameters(const mv::Dataset<Points>& inputData, const std::vector<bool>&& enabledDimensions, const HsneParameters& parameters, const KnnParameters& knnParameters)
+void HsneHierarchy::setDataAndParameters(const mv::Dataset<Points>& inputData, const mv::Dataset<Points>& outputData, const HsneParameters& parameters, const KnnParameters& knnParameters, std::vector<bool>&& enabledDimensions)
 {
     // Convert our own HSNE parameters to the HDI parameters
     _params = setParameters(parameters, knnParameters);
@@ -145,6 +145,7 @@ void HsneHierarchy::setDataAndParameters(const mv::Dataset<Points>& inputData, c
 
     // Save enabled dimensions and data set to retrieve data
     _inputData = inputData;
+    _outputData = outputData;
     _enabledDimensions = std::move(enabledDimensions);
 
     // Extract the enabled dimensions from the data
@@ -204,7 +205,7 @@ void HsneHierarchy::initialize()
         // Set the dimensionality of the data in the HSNE object
         _hsne->setDimensionality(_numDimensions);
 
-        auto& datasetTask = _inputData->getTask();
+        auto& datasetTask = _outputData->getTask();
         datasetTask.setName("Initialize HSNE hierachy");
         datasetTask.setRunning();
         datasetTask.setProgress(.0f);

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -235,7 +235,7 @@ void HsneHierarchy::initialize()
         datasetTask.setProgress(.9f);
 
         // Write HSNE hierarchy to disk
-        if(parameters.getSaveHierarchyToDisk())
+        if(_saveHierarchyToDisk)
             saveCacheHsne(_params); 
 
         datasetTask.setFinished();
@@ -360,6 +360,9 @@ void HsneHierarchy::saveCacheParameters(std::string fileName, const Hsne::Parame
 
 
 bool HsneHierarchy::loadCache(const Hsne::Parameters& internalParams, hdi::utils::CoutLog& log) {
+    if (!_saveHierarchyToDisk)
+        return false;
+
     std::cout << "HsneHierarchy::loadCache(): attempt to load cache from " + _cachePathFileName.string() << std::endl;
 
     auto pathParameter = _cachePathFileName.string() + _PARAMETERS_CACHE_EXTENSION_;

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -72,7 +72,7 @@ signals:
     void finished();
 
 public:
-    void setDataAndParameters(const mv::Dataset<Points>& inputData, const std::vector<bool>&& enabledDimensions, const HsneParameters& parameters, const KnnParameters& knnParameters);
+    void setDataAndParameters(const mv::Dataset<Points>& inputData, const mv::Dataset<Points>& outputData, const HsneParameters& parameters, const KnnParameters& knnParameters, std::vector<bool>&& enabledDimensions);
 
     HsneMatrix getTransitionMatrixAtScale(int scale) { return _hsne->scale(scale)._transition_matrix; }
 
@@ -152,6 +152,7 @@ private:
 
     std::vector<bool>       _enabledDimensions;
     mv::Dataset<Points>     _inputData;
+    mv::Dataset<Points>     _outputData;
     std::string             _inputDataName;
 
     int                     _numScales = 1;

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -154,6 +154,7 @@ private:
     mv::Dataset<Points>     _inputData;
     mv::Dataset<Points>     _outputData;
     std::string             _inputDataName;
+    mv::Task*               _parentTask = nullptr;
 
     int                     _numScales = 1;
     unsigned int            _numPoints = 0;

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -4,16 +4,19 @@
 #include "hdi/utils/cout_log.h"
 #include "hdi/utils/graph_algorithms.h"
 
+#include "PointData/PointData.h"
+
 #include <filesystem>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include <QObject>
+
 using HsneMatrix = std::vector<hdi::data::MapMemEff<uint32_t, float>>;
 using Hsne = hdi::dr::HierarchicalSNE<float, HsneMatrix>;
 
-class Points;
 class HsneParameters;
 class KnnParameters;
 class HsneHierarchy;
@@ -34,8 +37,10 @@ using Path = std::filesystem::path;
  *
  * @author Julian Thijssen
  */
-class InfluenceHierarchy
+class InfluenceHierarchy : public QObject
 {
+    Q_OBJECT
+
 public:
     void initialize(HsneHierarchy& hierarchy);
 
@@ -53,18 +58,21 @@ private:
  *
  * @author Julian Thijssen
  */
-class HsneHierarchy
+class HsneHierarchy : public QObject
 {
-public:
-    /**
-     * Initialize the HSNE hierarchy with a data-level scale.
-     *
-     * @param  data        The high-dimensional data
-     * @param  parameters  Parameters with which to run the HSNE algorithm
-     */
-    void initialize(const Points& inputData, const std::vector<bool>& enabledDimensions, const HsneParameters& parameters, const KnnParameters& knnParameters);
+    Q_OBJECT
 
-    void setDataAndParameters(const Points& inputData, const std::vector<bool>& enabledDimensions, const HsneParameters& parameters, const KnnParameters& knnParameters);
+public slots:
+    /**
+     * Initialize the HSNE hierarchy with a data-level scale. First call setDataAndParameters() 
+     */
+    void initialize();
+
+signals:
+    void finished();
+
+public:
+    void setDataAndParameters(const mv::Dataset<Points>& inputData, const std::vector<bool>&& enabledDimensions, const HsneParameters& parameters, const KnnParameters& knnParameters);
 
     HsneMatrix getTransitionMatrixAtScale(int scale) { return _hsne->scale(scale)._transition_matrix; }
 
@@ -140,8 +148,11 @@ protected:
 
 private:
     std::unique_ptr<Hsne>   _hsne;
-
     InfluenceHierarchy      _influenceHierarchy;
+
+    std::vector<bool>       _enabledDimensions;
+    mv::Dataset<Points>     _inputData;
+    std::string             _inputDataName;
 
     int                     _numScales = 1;
     unsigned int            _numPoints = 0;
@@ -151,7 +162,7 @@ private:
 
     Path                    _cachePath;                            /** Path for saving and loading cache */
     Path                    _cachePathFileName;                    /** cachePath() + data name */
-    std::string             _inputDataName;
+    bool                    _saveHierarchyToDisk = false;
 
     friend class HsneAnalysisPlugin;
 };


### PR DESCRIPTION
Until now, the HSNE hierarchy was initialized in the GUI thread and thereby blocked the entire application.

This PR moves the initialization into its own thread, similar to how the gradient descent in `TsneAnalysis.cpp` is moved to another thread.