### PR TITLE
Fix crash when deleting top level embedding before computing it

### DIFF
--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -218,6 +218,9 @@ void HsneAnalysisPlugin::init()
         // If the removed dataset is the output data (top level embedding), remove the accompanying _selectionHelperData
         if (outputDatasetID == datasetID)
         {
+            if (!_selectionHelperData.isValid())
+                return;
+
             qDebug() << "HSNE Plugin: remove (invisible) selection helper dataset " << _selectionHelperData->getId() << " used for deleted " << datasetID;
             mv::data().removeDataset(_selectionHelperData);
         }


### PR DESCRIPTION
Currently, when you delete the top level embedding before starting the HSNE computation, the program will crash.

Solution: Check if  `_selectionHelperData` exists before deleting