### PR TITLE
Add unity build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ project("SNE-Analyses" C CXX)
 # -----------------------------------------------------------------------------
 option(USE_ARTIFACTORY_LIBS "Use the prebuilt libraries from artifactory" ON)
 option(ENABLE_AVX "Enable AVX support" OFF)
+option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
 set(OPTIMIZATION_LEVEL "2" CACHE STRING "Optimization level for all targets in release builds, e.g. 0, 1, 2")
-        
+
 # -----------------------------------------------------------------------------
 # CMake options
 # -----------------------------------------------------------------------------

--- a/cmake/CMakeHsneProject.cmake
+++ b/cmake/CMakeHsneProject.cmake
@@ -47,6 +47,10 @@ set_target_properties(${HSNE_PLUGIN} PROPERTIES CXX_STANDARD 17)
 
 target_compile_definitions(${HSNE_PLUGIN} PRIVATE QT_MESSAGELOGCONTEXT)
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${HSNE_PLUGIN} PROPERTIES UNITY_BUILD ON)
+endif()
+
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------

--- a/cmake/CMakeTsneProject.cmake
+++ b/cmake/CMakeTsneProject.cmake
@@ -44,6 +44,10 @@ set_target_properties(${TSNE_PLUGIN} PROPERTIES CXX_STANDARD 17)
 
 target_compile_definitions(${TSNE_PLUGIN} PRIVATE QT_MESSAGELOGCONTEXT)
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${TSNE_PLUGIN} PROPERTIES UNITY_BUILD ON)
+endif()
+
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------

--- a/conanfile.py
+++ b/conanfile.py
@@ -121,7 +121,10 @@ class SNEAnalysesConan(ConanFile):
         self.install_dir = pathlib.Path(os.environ["MV_INSTALL_DIR"]).as_posix()
         # Give the installation directory to CMake
         tc.variables["MV_INSTALL_DIR"] = self.install_dir
-        
+
+        # Set some build options
+        tc.variables["MV_UNITY_BUILD"] = "ON"
+
         tc.generate()
 
     def _configure_cmake(self):


### PR DESCRIPTION
Adds optional [unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html): `OFF` by default, except on CI where it's `ON`.