### PR TITLE
HDIlib 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ include(InstallArtifactoryPackage)
 if (USE_ARTIFACTORY_LIBS AND NOT ARTIFACTORY_LIBS_INSTALLED) 
     message(STATUS "Installing artifactory packages to: ${LIBRARY_INSTALL_DIR}")
 
-    set(HDILib_VERSION 1.2.7)
+    set(HDILib_VERSION 1.3.0)
     set(flann_VERSION 1.9.2)
     set(lz4_VERSION 1.9.3)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,7 +75,7 @@ class SNEAnalysesConan(ConanFile):
 
     def requirements(self):
         #if os.environ.get("CONAN_REQUIRE_HDILIB", None) is not None:
-        #    self.requires("HDILib/1.2.6@biovault/stable")
+        #    self.requires("HDILib/1.3.0@biovault/stable")
         branch_info = PluginBranchInfo(self.__get_git_path())
         print(f"Core requirement {branch_info.core_requirement}")
         self.requires(branch_info.core_requirement)

--- a/src/Common/TsneAnalysis.cpp
+++ b/src/Common/TsneAnalysis.cpp
@@ -28,11 +28,15 @@ TsneWorker::TsneWorker(TsneParameters tsneParameters) :
     _outEmbedding(),
     _offscreenBuffer(nullptr),
     _shouldStop(false),
+    _logger(),
     _parentTask(nullptr),
     _tasks(nullptr)
 {
     // Offscreen buffer must be created in the UI thread because it is a QWindow, afterwards we move it
     _offscreenBuffer = new OffscreenBuffer();
+
+    _GPGPU_tSNE.setLogger(&_logger);
+    _CPU_tSNE.setLogger(&_logger);
 }
 
 TsneWorker::TsneWorker(TsneParameters tsneParameters, KnnParameters knnParameters, const std::vector<float>& data, uint32_t numDimensions, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding) :
@@ -198,6 +202,8 @@ void TsneWorker::computeSimilarities()
         qDebug() << "Sparse matrix allocated.";
 
         hdi::dr::HDJointProbabilityGenerator<float> probabilityGenerator;
+
+        probabilityGenerator.setLogger(&_logger);
 
         qDebug() << "Computing high dimensional probability distributions: Num dims: " << _numDimensions << " Num data points: " << _numPoints;
         probabilityGenerator.computeJointProbabilityDistribution(_data.data(), _numDimensions, _numPoints, _probabilityDistribution, probGenParameters());         // The _probabilityDistribution is symmetrized here.

--- a/src/Common/TsneAnalysis.cpp
+++ b/src/Common/TsneAnalysis.cpp
@@ -63,7 +63,7 @@ TsneWorker::TsneWorker(TsneParameters parameters, KnnParameters knnParameters, s
         setInitEmbedding(*initEmbedding);
 }
 
-TsneWorker::TsneWorker(TsneParameters parameters, const std::vector<hdi::data::MapMemEff<uint32_t, float>>& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding) :
+TsneWorker::TsneWorker(TsneParameters parameters, const ProbDistMatrix& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding) :
     TsneWorker(parameters)
 {
     _probabilityDistribution = probDist;
@@ -75,7 +75,7 @@ TsneWorker::TsneWorker(TsneParameters parameters, const std::vector<hdi::data::M
         setInitEmbedding(*initEmbedding);
 }
 
-TsneWorker::TsneWorker(TsneParameters parameters, std::vector<hdi::data::MapMemEff<uint32_t, float>>&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding) :
+TsneWorker::TsneWorker(TsneParameters parameters, ProbDistMatrix&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding) :
     TsneWorker(parameters)
 {
     _probabilityDistribution = std::move(probDist);
@@ -441,7 +441,7 @@ void TsneAnalysis::deleteWorker()
     }
 }
 
-void TsneAnalysis::startComputation(TsneParameters parameters, const std::vector<hdi::data::MapMemEff<uint32_t, float>>& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding, int previousIterations)
+void TsneAnalysis::startComputation(TsneParameters parameters, const ProbDistMatrix& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding, int previousIterations)
 {
     deleteWorker();
 
@@ -453,7 +453,7 @@ void TsneAnalysis::startComputation(TsneParameters parameters, const std::vector
     startComputation(_tsneWorker);
 }
 
-void TsneAnalysis::startComputation(TsneParameters parameters, std::vector<hdi::data::MapMemEff<uint32_t, float>>&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding, int previousIterations)
+void TsneAnalysis::startComputation(TsneParameters parameters, ProbDistMatrix&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding, int previousIterations)
 {
     deleteWorker();
 

--- a/src/Common/TsneAnalysis.h
+++ b/src/Common/TsneAnalysis.h
@@ -8,6 +8,7 @@
 #include "hdi/dimensionality_reduction/hd_joint_probability_generator.h"
 #include "hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities.h"
 #include "hdi/dimensionality_reduction/tsne_parameters.h"
+#include "hdi/utils/cout_log.h"
 
 #include <Task.h>
 
@@ -105,6 +106,7 @@ private:
     GradienDescentCPU                       _CPU_tSNE;                      /** CPU t-SNE gradient descent implementation */
     hdi::data::Embedding<float>             _embedding;                     /** Storage of current embedding */
     TsneData                                _outEmbedding;                  /** Transfer embedding data array */
+    hdi::utils::CoutLog                     _logger;
     OffscreenBuffer*                        _offscreenBuffer;               /** Offscreen OpenGL buffer required to run the gradient descent */
     bool                                    _shouldStop;                    /** Termination flags */
 

--- a/src/Common/TsneAnalysis.h
+++ b/src/Common/TsneAnalysis.h
@@ -42,7 +42,7 @@ class TsneWorker : public QObject
 {
     Q_OBJECT
 
-    using GradienDescentGPU = hdi::dr::GradientDescentTSNETexture;
+    using GradienDescentGPU = hdi::dr::GradientDescentTSNETexture<float>;
     using GradienDescentCPU = hdi::dr::SparseTSNEUserDefProbabilities<float>;
 
 private:
@@ -54,9 +54,9 @@ public:
     // The tsne object will compute knn and a probablility distribution before starting the embedding, moving the input data
     TsneWorker(TsneParameters tsneParameters, KnnParameters knnParameters, std::vector<float>&& data, uint32_t numDimensions, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding);
     // The tsne object expects a probDist that is not symmetrized, no knn are computed
-    TsneWorker(TsneParameters tsneParameters, const std::vector<hdi::data::MapMemEff<uint32_t, float>>& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding);
+    TsneWorker(TsneParameters tsneParameters, const ProbDistMatrix& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding);
     // The tsne object expects a probDist that is not symmetrized, no knn are computed, moving the probDist
-    TsneWorker(TsneParameters tsneParameters, std::vector<hdi::data::MapMemEff<uint32_t, float>>&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding);
+    TsneWorker(TsneParameters tsneParameters, ProbDistMatrix&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding);
     ~TsneWorker();
 
     void createTasks();
@@ -123,9 +123,9 @@ public:
 public: // Interactions
     
     // Compute embedding based on pre-computed similarites
-    void startComputation(TsneParameters parameters, const std::vector<hdi::data::MapMemEff<uint32_t, float>>& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding = nullptr, int iterations = -1);
+    void startComputation(TsneParameters parameters, const ProbDistMatrix& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding = nullptr, int iterations = -1);
     // Compute embedding based on pre-computed similarites, moves the input probDist
-    void startComputation(TsneParameters parameters, std::vector<hdi::data::MapMemEff<uint32_t, float>>&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding = nullptr, int iterations = -1);
+    void startComputation(TsneParameters parameters, ProbDistMatrix&& probDist, uint32_t numPoints, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding = nullptr, int iterations = -1);
     // Compute similarities (aknn search) and embedding
     void startComputation(TsneParameters parameters, KnnParameters knnParameters, const std::vector<float>& data, uint32_t numDimensions, const hdi::data::Embedding<float>::scalar_vector_type* initEmbedding = nullptr);
     // Compute similarities (aknn search) and embedding, moves the input data

--- a/src/Common/TsneAnalysis.h
+++ b/src/Common/TsneAnalysis.h
@@ -118,7 +118,7 @@ private:
     GradienDescentCPU64                     _CPU_tSNE64;                    /** CPU t-SNE gradient descent implementation, 64 bit */
     hdi::data::Embedding<float>             _embedding;                     /** Storage of current embedding */
     TsneData                                _outEmbedding;                  /** Transfer embedding data array */
-    hdi::utils::CoutLog                     _logger;
+    hdi::utils::CoutLog                     _logger;                        /** HDILib logger class */
     OffscreenBuffer*                        _offscreenBuffer;               /** Offscreen OpenGL buffer required to run the gradient descent */
     bool                                    _use64BitImplementation;        /** Wheter to use 64 bit implementation for large data (cannot make use of compute shader) */
     bool                                    _shouldStop;                    /** Termination flags */

--- a/src/Common/TsneAnalysis.h
+++ b/src/Common/TsneAnalysis.h
@@ -100,6 +100,7 @@ private:
     ProbDistGenerator::Parameters probGenParameters();
     ProbDistGenerator64::Parameters probGenParameters64();
 
+    void check64bit();
     void resetThread();
 
 private:

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -308,17 +308,7 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
 
                 for (size_t i = 0; i < landmarkMap.size(); i++)
                 {
-                    const LandmarkMap::value_type& bottomMapGlobal = landmarkMap[i];
-                    mv::SelectionMap::Indices bottomMap;
-                    bottomMap.resize(bottomMapGlobal.size());
-
-                    // cast from 64int to 32 int
-#pragma omp parallel for
-                    for (int64_t j = 0; j < bottomMapGlobal.size(); j++)
-                        bottomMap[j] = static_cast<mv::SelectionMap::Indices::value_type>(bottomMapGlobal[j]);
-
-
-                    selectionMap[globalIndices[i]] = bottomMap;
+                    selectionMap[globalIndices[i]] = landmarkMap[i];
                 }
             }
             else

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -306,23 +306,36 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
                 std::vector<unsigned int> globalIndices;
                 _selectionHelperData->getGlobalIndices(globalIndices);
 
-                for (unsigned int i = 0; i < landmarkMap.size(); i++)
+                for (size_t i = 0; i < landmarkMap.size(); i++)
                 {
-                    selectionMap[globalIndices[i]] = landmarkMap[i];
+                    const LandmarkMap::value_type& bottomMapGlobal = landmarkMap[i];
+                    mv::SelectionMap::Indices bottomMap;
+                    bottomMap.resize(bottomMapGlobal.size());
+
+                    // cast from 64int to 32 int
+#pragma omp parallel for
+                    for (int64_t j = 0; j < bottomMapGlobal.size(); j++)
+                        bottomMap[j] = static_cast<mv::SelectionMap::Indices::value_type>(bottomMapGlobal[j]);
+
+
+                    selectionMap[globalIndices[i]] = bottomMap;
                 }
             }
             else
             {
                 std::vector<unsigned int> globalIndices;
                 inputDataset->getGlobalIndices(globalIndices);
-                for (unsigned int i = 0; i < landmarkMap.size(); i++)
+                for (size_t i = 0; i < landmarkMap.size(); i++)
                 {
-                    std::vector<unsigned int> bottomMap = landmarkMap[i];
-                    for (unsigned int j = 0; j < bottomMap.size(); j++)
-                    {
-                        bottomMap[j] = globalIndices[bottomMap[j]];
-                    }
-                    auto bottomLevelIdx = _hierarchy->getScale(topScaleIndex)._landmark_to_original_data_idx[i];
+                    const LandmarkMap::value_type& bottomMapGlobal = landmarkMap[i];
+                    mv::SelectionMap::Indices bottomMap;
+                    bottomMap.resize(bottomMapGlobal.size());
+
+#pragma omp parallel for
+                    for (int64_t j = 0; j < bottomMapGlobal.size(); j++)
+                        bottomMap[j] = static_cast<mv::SelectionMap::Indices::value_type>(globalIndices[bottomMapGlobal[j]]);
+
+                    int bottomLevelIdx = _hierarchy->getScale(topScaleIndex)._landmark_to_original_data_idx[i];
                     selectionMap[globalIndices[bottomLevelIdx]] = bottomMap;
                 }
             }

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -130,10 +130,12 @@ void InfluenceHierarchy::initialize(HsneHierarchy& hierarchy)
 
 void HsneHierarchy::printScaleInfo() const
 {
-    std::cout << "Landmark to Orig size: " << _hsne->scale(getNumScales() - 1)._landmark_to_original_data_idx.size() << std::endl;
-    std::cout << "Landmark to Prev size: " << _hsne->scale(getNumScales() - 1)._landmark_to_previous_scale_idx.size() << std::endl;
-    std::cout << "Prev to Landmark size: " << _hsne->scale(getNumScales() - 1)._previous_scale_to_landmark_idx.size() << std::endl;
-    std::cout << "AoI size: " << _hsne->scale(getNumScales() - 1)._area_of_influence.size() << std::endl;
+    const auto scaleID = static_cast<Hsne::unsigned_int_type>(getNumScales()) - 1;
+
+    std::cout << "Landmark to Orig size: " << _hsne->scale(scaleID)._landmark_to_original_data_idx.size() << std::endl;
+    std::cout << "Landmark to Prev size: " << _hsne->scale(scaleID)._landmark_to_previous_scale_idx.size() << std::endl;
+    std::cout << "Prev to Landmark size: " << _hsne->scale(scaleID)._previous_scale_to_landmark_idx.size() << std::endl;
+    std::cout << "AoI size: " << _hsne->scale(scaleID)._area_of_influence.size() << std::endl;
 }
 
 void HsneHierarchy::setDataAndParameters(const mv::Dataset<Points>& inputData, const mv::Dataset<Points>& outputData, const HsneParameters& parameters, const KnnParameters& knnParameters, std::vector<bool>&& enabledDimensions)

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -65,12 +65,12 @@ void InfluenceHierarchy::initialize(HsneHierarchy& hierarchy)
 
     auto& bottomScale = hierarchy.getScale(0);
 
-    int numDataPoints = bottomScale.size();
+    size_t numDataPoints = bottomScale.size();
 
 #pragma omp parallel for
-    for (int i = 0; i < numDataPoints; i++)
+    for (std::int64_t i = 0; i < numDataPoints; i++)
     {
-        std::vector<std::unordered_map<unsigned int, float>> influence;
+        std::vector<std::unordered_map<std::uint64_t, float>> influence;
 
         float thresh = 0.01f;
 

--- a/src/HSNE/HsneHierarchy.cpp
+++ b/src/HSNE/HsneHierarchy.cpp
@@ -70,7 +70,7 @@ void InfluenceHierarchy::initialize(HsneHierarchy& hierarchy)
 #pragma omp parallel for
     for (std::int64_t i = 0; i < numDataPoints; i++)
     {
-        std::vector<std::unordered_map<std::uint64_t, float>> influence;
+        std::vector<std::unordered_map<std::uint32_t, float>> influence;
 
         float thresh = 0.01f;
 

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -114,6 +114,8 @@ public:
      */
     void getTransitionMatrixForSelection(int currentScale, HsneMatrix& transitionMatrix, std::vector<uint32_t>& landmarkIdxs)
     {
+        assert(currentScale > 0);
+
         // Get full transition matrix of the previous scale
         HsneMatrix& fullTransitionMatrix = _hsne->scale(currentScale-1)._transition_matrix;
 

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -14,7 +14,7 @@
 
 #include <QObject>
 
-using HsneMatrix = std::vector<hdi::data::MapMemEff<uint32_t, float>>;
+using HsneMatrix = std::vector<hdi::data::MapMemEff<std::uint32_t, float>>;
 using Hsne = hdi::dr::HierarchicalSNE<float, HsneMatrix>;
 
 class HsneParameters;
@@ -98,12 +98,12 @@ public:
      * Returns a map of landmark indices and influences on the previous scale in the hierarchy,
      * that are influenced by landmarks specified by their index in the current scale.
      */
-    void getInfluencedLandmarksInPreviousScale(int currentScale, std::vector<unsigned int> indices, std::map<uint32_t, float>& neighbors)
+    void getInfluencedLandmarksInPreviousScale(int currentScale, std::vector<std::uint64_t> indices, std::map<std::uint64_t, float>& neighbors)
     {
         _hsne->getInfluencedLandmarksInPreviousScale(currentScale, indices, neighbors);
     }
 
-    void getInfluenceOnDataPoint(unsigned int dataPointId, std::vector<std::unordered_map<unsigned int, float>>& influence, float thresh = 0, bool normalized = true)
+    void getInfluenceOnDataPoint(std::uint64_t dataPointId, std::vector<std::unordered_map<std::uint64_t, float>>& influence, float thresh = 0, bool normalized = true)
     {
         _hsne->getInfluenceOnDataPoint(dataPointId, influence, thresh, normalized);
     }
@@ -118,7 +118,7 @@ public:
         HsneMatrix& fullTransitionMatrix = _hsne->scale(currentScale-1)._transition_matrix;
 
         // Extract the selected subportion of the transition matrix
-        std::vector<unsigned int> dummy;
+        std::vector<std::uint32_t> dummy;
         hdi::utils::extractSubGraph(fullTransitionMatrix, landmarkIdxs, transitionMatrix, dummy, 1);
     }
 

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -14,7 +14,7 @@
 
 #include <QObject>
 
-using HsneMatrix    = std::vector<hdi::data::MapMemEff<std::uint64_t, float>>;
+using HsneMatrix    = std::vector<hdi::data::MapMemEff<std::uint32_t, float>>;
 using Hsne          = hdi::dr::HierarchicalSNE<float, HsneMatrix>;
 
 class HsneParameters;
@@ -29,7 +29,7 @@ namespace mv {
     }
 }
 
-using LandmarkMap = std::vector<std::vector<std::uint64_t>>;
+using LandmarkMap = std::vector<std::vector<std::uint32_t>>;
 using Path = std::filesystem::path;
 
 /**
@@ -98,12 +98,12 @@ public:
      * Returns a map of landmark indices and influences on the previous scale in the hierarchy,
      * that are influenced by landmarks specified by their index in the current scale.
      */
-    void getInfluencedLandmarksInPreviousScale(int currentScale, std::vector<std::uint64_t> indices, std::map<std::uint64_t, float>& neighbors)
+    void getInfluencedLandmarksInPreviousScale(int currentScale, std::vector<std::uint32_t> indices, std::map<std::uint32_t, float>& neighbors)
     {
         _hsne->getInfluencedLandmarksInPreviousScale(currentScale, indices, neighbors);
     }
 
-    void getInfluenceOnDataPoint(std::uint64_t dataPointId, std::vector<std::unordered_map<std::uint64_t, float>>& influence, float thresh = 0, bool normalized = true)
+    void getInfluenceOnDataPoint(std::uint32_t dataPointId, std::vector<std::unordered_map<std::uint32_t, float>>& influence, float thresh = 0, bool normalized = true)
     {
         _hsne->getInfluenceOnDataPoint(dataPointId, influence, thresh, normalized);
     }
@@ -112,7 +112,7 @@ public:
      * Extract a subgraph with the selected indexes and the vertices connected to them by an edge with a weight higher then thresh
      * 
      */
-    void getTransitionMatrixForSelection(int currentScale, HsneMatrix& transitionMatrix, std::vector<uint32_t>& landmarkIdxs)
+    void getTransitionMatrixForSelection(int currentScale, HsneMatrix& transitionMatrix, std::vector<std::uint32_t>& landmarkIdxs)
     {
         assert(currentScale > 0);
 

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -14,8 +14,8 @@
 
 #include <QObject>
 
-using HsneMatrix = std::vector<hdi::data::MapMemEff<std::uint32_t, float>>;
-using Hsne = hdi::dr::HierarchicalSNE<float, HsneMatrix>;
+using HsneMatrix    = std::vector<hdi::data::MapMemEff<std::uint64_t, float>>;
+using Hsne          = hdi::dr::HierarchicalSNE<float, HsneMatrix>;
 
 class HsneParameters;
 class KnnParameters;
@@ -29,7 +29,7 @@ namespace mv {
     }
 }
 
-using LandmarkMap = std::vector<std::vector<unsigned int>>;
+using LandmarkMap = std::vector<std::vector<std::uint64_t>>;
 using Path = std::filesystem::path;
 
 /**
@@ -117,7 +117,7 @@ public:
         assert(currentScale > 0);
 
         // Get full transition matrix of the previous scale
-        HsneMatrix& fullTransitionMatrix = _hsne->scale(currentScale-1)._transition_matrix;
+        HsneMatrix& fullTransitionMatrix = _hsne->scale(static_cast<Hsne::unsigned_int_type>(currentScale) - 1)._transition_matrix;
 
         // Extract the selected subportion of the transition matrix
         std::vector<std::uint32_t> dummy;

--- a/src/HSNE/HsneHierarchy.h
+++ b/src/HSNE/HsneHierarchy.h
@@ -130,26 +130,26 @@ public:
     int getNumPoints() const { return _numPoints; }
     int getNumDimensions() const { return _numDimensions; }
 
+protected:
     /** Save HSNE hierarchy from this class to disk */
-    void saveCacheHsne(const Hsne::Parameters& internalParams) const;
+    void saveCacheHsne() const;
 
     /** Load HSNE hierarchy from disk */
-    bool loadCache(const Hsne::Parameters& internalParams, hdi::utils::CoutLog& log);
+    bool loadCache(hdi::utils::CoutLog& log);
 
-protected:
     /** Save HsneHierarchy to disk */
     void saveCacheHsneHierarchy(std::string fileName) const;
     /** Save InfluenceHierarchy to disk */
     void saveCacheHsneInfluenceHierarchy(std::string fileName, const std::vector<LandmarkMap>& influenceHierarchy) const;
     /** Save HSNE parameters to disk */
-    void saveCacheParameters(std::string fileName, const Hsne::Parameters& internalParams) const;
+    void saveCacheParameters(std::string fileName) const;
 
     /** Load HsneHierarchy from disk */
     bool loadCacheHsneHierarchy(std::string fileName, hdi::utils::CoutLog& _log);
     /** Load InfluenceHierarchy from disk */
     bool loadCacheHsneInfluenceHierarchy(std::string fileName, std::vector<LandmarkMap>& influenceHierarchy);
     /** Check whether HSNE parameters of the cached values on disk correspond with the current settings */
-    bool checkCacheParameters(const std::string fileName, const Hsne::Parameters& params) const;
+    bool checkCacheParameters(const std::string fileName) const;
 
     void setIsInitialized(bool init) { _isInit = true; }
 
@@ -166,7 +166,8 @@ private:
     int                     _numScales = 1;
     unsigned int            _numPoints = 0;
     unsigned int            _numDimensions = 0;
-    Hsne::Parameters        _params;
+    
+    Hsne::Parameters        _params = {};
     bool                    _isInit = false;
 
     Path                    _cachePath;                            /** Path for saving and loading cache */

--- a/src/HSNE/HsneScaleAction.cpp
+++ b/src/HSNE/HsneScaleAction.cpp
@@ -235,8 +235,8 @@ void HsneScaleAction::refine()
     _embedding->selectedLocalIndices(selection->indices, selectedLocalIndices);
 
     // Transform local indices to scale relative indices
-    std::vector<unsigned int> selectedLandmarks; // Selected indices relative to scale
-    for (int i = 0; i < selectedLocalIndices.size(); i++)
+    std::vector<std::uint64_t> selectedLandmarks; // Selected indices relative to scale
+    for (size_t i = 0; i < selectedLocalIndices.size(); i++)
     {
         if (selectedLocalIndices[i])
         {
@@ -245,7 +245,7 @@ void HsneScaleAction::refine()
     }
     
     // Find the points in the previous level corresponding to selected landmarks
-    std::map<uint32_t, float> neighbors;
+    std::map<std::uint64_t, float> neighbors;
     _hsneHierarchy.getInfluencedLandmarksInPreviousScale(_currentScaleLevel, selectedLandmarks, neighbors);
 
     // Threshold neighbours with enough influence, these represent the indices of the refined points relative to their HSNE scale


### PR DESCRIPTION
Updates the HDILib to version 1.3.0, see https://github.com/biovault/HDILib/pull/36 :
- Use 64bit indices wherever indexing into data structures with multiple values per data point, e.g. knn neighbor indices
- Ensures that large HSNE hierarchies can be saved to disk without int overflows

Also, adds a logger to the t-SNE computation as is already the case with HSNE. 