### PR TITLE
Fix single scale selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ cmake --build build --config Release --target install
 - kNN (specify search structure construction and query characteristics):
   - (Annoy) Trees & Checks: correspond to `n_trees` and `search_k`, see their [docs](https://github.com/spotify/annoy?tab=readme-ov-file#tradeoffs)
   - (HNSW): M & ef: are detailed in the respective [docs](https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md#hnsw-algorithm-parameters)
+- HSNE:
+  - The number of scales includes the data scale, i.e., a setting of 2 scales indicates one abstraction scale above the data scale. Specifying 1 scale will not compute any abstraction level.

--- a/src/HSNE/GeneralHsneSettingsAction.cpp
+++ b/src/HSNE/GeneralHsneSettingsAction.cpp
@@ -7,7 +7,7 @@ using namespace mv::gui;
 GeneralHsneSettingsAction::GeneralHsneSettingsAction(HsneSettingsAction& hsneSettingsAction) :
     GroupAction(&hsneSettingsAction, "HSNE", true),
     _hsneSettingsAction(hsneSettingsAction),
-    _numScalesAction(this, "Number of Hierarchy Scales"),
+    _numScalesAction(this, "Hierarchy Scales"),
     _knnAlgorithmAction(this, "kNN Algorithm"),
     _distanceMetricAction(this, "Distance metric"),
     _numKnnAction(this, "Number of NN"),
@@ -29,6 +29,7 @@ GeneralHsneSettingsAction::GeneralHsneSettingsAction(HsneSettingsAction& hsneSet
     _distanceMetricAction.initialize(QStringList({ "Euclidean", "Cosine", "Inner Product", "Manhattan", "Hamming", "Dot" }), "Euclidean");
     _numKnnAction.initialize(3, 300, 90);
 
+    _numScalesAction.setToolTip("Number of hierarchy scales: e.g. 2 scales indicates one abstraction scale \nabove the data level, which is a scale itself.");
     _startAction.setToolTip("Initialize the HSNE hierarchy and create an embedding");
 
     const auto updateNumScales = [this]() -> void {

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -261,7 +261,7 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
     // Number of landmarks on the top scale
     const uint32_t numLandmarks = topScale.size();
 
-    // Only create new selection helper if it does not exist yet
+    // Only create new selection helper if a) it does not exist yet and b) we are above the data scale
     if (!_selectionHelperData.isValid() && topScaleIndex > 0)
     {
         // Create a subset of the points corresponding to the top level HSNE landmarks,

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -274,14 +274,14 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
 
         if (inputDataset->isFull())
         {
-            for (int i = 0; i < numLandmarks; i++)
+            for (uint32_t i = 0; i < numLandmarks; i++)
                 selectionDataset->indices[i] = topScale._landmark_to_original_data_idx[i];
         }
         else
         {
             std::vector<unsigned int> globalIndices;
             inputDataset->getGlobalIndices(globalIndices);
-            for (int i = 0; i < numLandmarks; i++)
+            for (uint32_t i = 0; i < numLandmarks; i++)
                 selectionDataset->indices[i] = globalIndices[topScale._landmark_to_original_data_idx[i]];
         }
 
@@ -306,7 +306,7 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
                 std::vector<unsigned int> globalIndices;
                 _selectionHelperData->getGlobalIndices(globalIndices);
 
-                for (int i = 0; i < landmarkMap.size(); i++)
+                for (unsigned int i = 0; i < landmarkMap.size(); i++)
                 {
                     selectionMap[globalIndices[i]] = landmarkMap[i];
                 }
@@ -315,14 +315,14 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
             {
                 std::vector<unsigned int> globalIndices;
                 inputDataset->getGlobalIndices(globalIndices);
-                for (int i = 0; i < landmarkMap.size(); i++)
+                for (unsigned int i = 0; i < landmarkMap.size(); i++)
                 {
                     std::vector<unsigned int> bottomMap = landmarkMap[i];
-                    for (int j = 0; j < bottomMap.size(); j++)
+                    for (unsigned int j = 0; j < bottomMap.size(); j++)
                     {
                         bottomMap[j] = globalIndices[bottomMap[j]];
                     }
-                    int bottomLevelIdx = _hierarchy->getScale(topScaleIndex)._landmark_to_original_data_idx[i];
+                    auto bottomLevelIdx = _hierarchy->getScale(topScaleIndex)._landmark_to_original_data_idx[i];
                     selectionMap[globalIndices[bottomLevelIdx]] = bottomMap;
                 }
             }

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -252,17 +252,17 @@ void HsneAnalysisPlugin::computeTopLevelEmbedding()
     datasetTask.setRunning();
 
     // Get the top scale of the HSNE hierarchy
-    int topScaleIndex = _hierarchy->getTopScale();
+    const int topScaleIndex = _hierarchy->getTopScale();
     Hsne::scale_type& topScale = _hierarchy->getScale(topScaleIndex);
     _hsneSettingsAction->getTopLevelScaleAction().setScale(topScaleIndex);
 
     _hierarchy->printScaleInfo();
 
     // Number of landmarks on the top scale
-    int numLandmarks = topScale.size();
+    const uint32_t numLandmarks = topScale.size();
 
     // Only create new selection helper if it does not exist yet
-    if (!_selectionHelperData.isValid())
+    if (!_selectionHelperData.isValid() && topScaleIndex > 0)
     {
         // Create a subset of the points corresponding to the top level HSNE landmarks,
         // Then derive the embedding from this subset

--- a/src/HSNE/HsneScaleAction.cpp
+++ b/src/HSNE/HsneScaleAction.cpp
@@ -159,7 +159,7 @@ void HsneScaleAction::initLayoutAndConnection()
         auto selection = _input->getSelection<Points>();
         const auto enabled = !isReadOnly();
 
-        _refineAction.setEnabled(!isReadOnly() && !selection->indices.empty());
+        _refineAction.setEnabled(!isReadOnly() && !selection->indices.empty() && _hsneHierarchy.getNumScales() > 1);
         _computationAction.getNumIterationsAction().setEnabled(enabled);
     };
 


### PR DESCRIPTION
Issue: When only computing a single scale HSNE...
- selecting landmarks does not work (e.g. in the scatterplot),
- you can drill down, which causes a crash

Fix:
- [No selection helper required for single scale hierarchies](https://github.com/ManiVaultStudio/t-SNE-Analysis/commit/ea1cb3bad626ce30fe5084ebef3b9ad46c260c4e). We do not need any mapping to the data level, since we are on the data level.
- [Do not enable drill down for a hierarchy with just a single scale](https://github.com/ManiVaultStudio/t-SNE-Analysis/commit/62f39dc3d57e1104d6ed806cf6bbfba9b9d061dc)