### PR TITLE
Stop t-SNE from overflowing the stack.

### DIFF
--- a/src/tSNE/TsneAnalysisPlugin.cpp
+++ b/src/tSNE/TsneAnalysisPlugin.cpp
@@ -145,8 +145,6 @@ void TsneAnalysisPlugin::init()
 
         _tsneSettingsAction->getGeneralTsneSettingsAction().getNumberOfComputatedIterationsAction().setValue(_tsneAnalysis.getNumIterations() - 1);
 
-        QCoreApplication::processEvents();
-
         // Notify others that the embedding data changed
         events().notifyDatasetDataChanged(getOutputDataset());
     });


### PR DESCRIPTION
This happens because the TSNE workers is throwing out embeddingUpdate signals in a parallel thread.
The main thread then calls processEvents on a regular basis, which handles the event, but this handler calls processEvents again. As there are plenty of signals to process (coming from the parallel worker) it will just keep recursing.
