### PR TITLE
Fix init data picker

### DIFF
--- a/src/Common/GradientDescentSettingsAction.cpp
+++ b/src/Common/GradientDescentSettingsAction.cpp
@@ -22,8 +22,8 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
     _exponentialDecayAction.setDefaultWidgetFlags(IntegralAction::SpinBox);
 
     _exaggerationFactorAction.initialize(0, 20, 4);
-    _exaggerationIterAction.initialize(1, 10000, 250);
-    _exponentialDecayAction.initialize(1, 10000, 70);
+    _exaggerationIterAction.initialize(0, 10000, 250);
+    _exponentialDecayAction.initialize(0, 10000, 70);
 
     _gradienDescentTypeAction.initialize({ "GPU", "CPU" });
 

--- a/src/Common/GradientDescentSettingsAction.cpp
+++ b/src/Common/GradientDescentSettingsAction.cpp
@@ -10,12 +10,12 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
     _exaggerationFactorAction(this, "Exaggeration factor"),
     _exaggerationIterAction(this, "Exaggeration iterations"),
     _exponentialDecayAction(this, "Exponential decay"),
-    _gradienDescentTypeAction(this, "GD implementation")
+    _gradientDescentTypeAction(this, "GD implementation")
 {
     addAction(&_exaggerationFactorAction);
     addAction(&_exaggerationIterAction);
     addAction(&_exponentialDecayAction);
-    addAction(&_gradienDescentTypeAction);
+    addAction(&_gradientDescentTypeAction);
 
     _exaggerationFactorAction.setDefaultWidgetFlags(IntegralAction::SpinBox);
     _exaggerationIterAction.setDefaultWidgetFlags(IntegralAction::SpinBox);
@@ -25,11 +25,11 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
     _exaggerationIterAction.initialize(0, 10000, 250);
     _exponentialDecayAction.initialize(0, 10000, 70);
 
-    _gradienDescentTypeAction.initialize({ "GPU", "CPU" });
+    _gradientDescentTypeAction.initialize({ "GPU", "CPU" });
 
     _exaggerationFactorAction.setToolTip("Defaults to 4 + number of points / 60'000");
     _exponentialDecayAction.setToolTip("Iterations after 'Exaggeration iterations' during \nwhich the exaggeration factor exponentionally decays towards 1");
-    _gradienDescentTypeAction.setToolTip("Gradient Descent Implementation: GPU (A-tSNE), CPU (Barnes-Hut)");
+    _gradientDescentTypeAction.setToolTip("Gradient Descent Implementation: GPU (A-tSNE), CPU (Barnes-Hut)");
 
     const auto updateExaggerationFactor = [this]() -> void {
         _tsneParameters.setExaggerationFactor(_exaggerationFactorAction.getValue());
@@ -43,11 +43,11 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
         _tsneParameters.setExponentialDecayIter(_exponentialDecayAction.getValue());
     };
 
-    const auto updateGradienDescentTypeAction = [this]() -> void {
-        switch (_gradienDescentTypeAction.getCurrentIndex())
+    const auto updateGradientDescentTypeAction = [this]() -> void {
+        switch (_gradientDescentTypeAction.getCurrentIndex())
         {
-        case 0: _tsneParameters.setGradienDescentType(GradienDescentType::GPU); break;
-        case 1: _tsneParameters.setGradienDescentType(GradienDescentType::CPU); break;
+        case 0: _tsneParameters.setGradientDescentType(GradientDescentType::GPU); break;
+        case 1: _tsneParameters.setGradientDescentType(GradientDescentType::CPU); break;
         }
         
     };
@@ -58,7 +58,7 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
         _exaggerationFactorAction.setEnabled(enable);
         _exaggerationIterAction.setEnabled(enable);
         _exponentialDecayAction.setEnabled(enable);
-        _gradienDescentTypeAction.setEnabled(enable);
+        _gradientDescentTypeAction.setEnabled(enable);
     };
 
     connect(&_exaggerationFactorAction, &DecimalAction::valueChanged, this, [this, updateExaggerationFactor](const float value) {
@@ -73,8 +73,8 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
         updateExponentialDecay();
     });
 
-    connect(&_gradienDescentTypeAction, &OptionAction::currentIndexChanged, this, [this, updateGradienDescentTypeAction](const std::int32_t& currentIndex) {
-        updateGradienDescentTypeAction();
+    connect(&_gradientDescentTypeAction, &OptionAction::currentIndexChanged, this, [this, updateGradientDescentTypeAction](const std::int32_t& currentIndex) {
+        updateGradientDescentTypeAction();
     });
 
     connect(this, &GroupAction::readOnlyChanged, this, [this, updateReadOnly](const bool& readOnly) {
@@ -84,7 +84,7 @@ GradientDescentSettingsAction::GradientDescentSettingsAction(QObject* parent, Ts
     updateExaggerationFactor();
     updateExaggerationIter();
     updateExponentialDecay();
-    updateGradienDescentTypeAction();
+    updateGradientDescentTypeAction();
     updateReadOnly();
 }
 
@@ -95,7 +95,7 @@ void GradientDescentSettingsAction::fromVariantMap(const QVariantMap& variantMap
     _exaggerationFactorAction.fromParentVariantMap(variantMap);
     _exaggerationIterAction.fromParentVariantMap(variantMap);
     _exponentialDecayAction.fromParentVariantMap(variantMap);
-    _gradienDescentTypeAction.fromParentVariantMap(variantMap);
+    _gradientDescentTypeAction.fromParentVariantMap(variantMap);
 }
 
 QVariantMap GradientDescentSettingsAction::toVariantMap() const
@@ -105,7 +105,7 @@ QVariantMap GradientDescentSettingsAction::toVariantMap() const
     _exaggerationFactorAction.insertIntoVariantMap(variantMap);
     _exaggerationIterAction.insertIntoVariantMap(variantMap);
     _exponentialDecayAction.insertIntoVariantMap(variantMap);
-    _gradienDescentTypeAction.insertIntoVariantMap(variantMap);
+    _gradientDescentTypeAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/src/Common/GradientDescentSettingsAction.h
+++ b/src/Common/GradientDescentSettingsAction.h
@@ -31,7 +31,7 @@ public: // Action getters
     DecimalAction& getExaggerationFactorAction() { return _exaggerationFactorAction; };
     IntegralAction& getExaggerationIterAction() { return _exaggerationIterAction; };
     IntegralAction& getExponentialDecayAction() { return _exponentialDecayAction; };
-    OptionAction& getGadienDescentTypeAction() { return _gradienDescentTypeAction; };
+    OptionAction& getGradientDescentTypeAction() { return _gradientDescentTypeAction; };
 
 public: // Serialization
 
@@ -52,5 +52,5 @@ protected:
     DecimalAction           _exaggerationFactorAction;  /** Exaggeration factor action */
     IntegralAction          _exaggerationIterAction;    /** Exaggeration iteration action */
     IntegralAction          _exponentialDecayAction;    /** Exponential decay action */
-    OptionAction            _gradienDescentTypeAction;  /** GPU or CPU gradient descent */
+    OptionAction            _gradientDescentTypeAction; /** GPU or CPU gradient descent */
 };

--- a/src/Common/TsneAnalysis.cpp
+++ b/src/Common/TsneAnalysis.cpp
@@ -266,7 +266,7 @@ void TsneWorker::computeGradientDescent(uint32_t iterations)
         {
             hdi::utils::ScopedTimer<double> timer(t_init);
 
-            if (_tsneParameters.getGradienDescentType() == GradienDescentType::GPU)
+            if (_tsneParameters.getGradientDescentType() == GradientDescentType::GPU)
                 initGPUTSNE();
             else
                 initCPUTSNE();
@@ -277,14 +277,14 @@ void TsneWorker::computeGradientDescent(uint32_t iterations)
     };
 
     auto singleTSNEIteration = [this]() {
-        if (_tsneParameters.getGradienDescentType() == GradienDescentType::GPU)
+        if (_tsneParameters.getGradientDescentType() == GradientDescentType::GPU)
             _GPGPU_tSNE.doAnIteration();
         else
             _CPU_tSNE.doAnIteration();
     };
 
     auto gradientDescentCleanup = [this]() {
-        if (_tsneParameters.getGradienDescentType() == GradienDescentType::GPU)
+        if (_tsneParameters.getGradientDescentType() == GradientDescentType::GPU)
             _offscreenBuffer->releaseContext();
         else
             return; // Nothing to do for CPU implementation

--- a/src/Common/TsneAnalysis.h
+++ b/src/Common/TsneAnalysis.h
@@ -42,8 +42,8 @@ class TsneWorker : public QObject
 {
     Q_OBJECT
 
-    using GradienDescentGPU = hdi::dr::GradientDescentTSNETexture;
-    using GradienDescentCPU = hdi::dr::SparseTSNEUserDefProbabilities<float>;
+    using GradientDescentGPU = hdi::dr::GradientDescentTSNETexture;
+    using GradientDescentCPU = hdi::dr::SparseTSNEUserDefProbabilities<float>;
 
 private:
     // default construction is inaccessible to outsiders
@@ -101,8 +101,8 @@ private:
     std::vector<float>                      _data;                          /** High-dimensional input data */
     ProbDistMatrix                          _probabilityDistribution;       /** High-dimensional probability distribution encoding point similarities */
     bool                                    _hasProbabilityDistribution;    /** Check if the worker was initialized with a probability distribution or data */
-    GradienDescentGPU                       _GPGPU_tSNE;                    /** GPGPU t-SNE gradient descent implementation */
-    GradienDescentCPU                       _CPU_tSNE;                      /** CPU t-SNE gradient descent implementation */
+    GradientDescentGPU                       _GPGPU_tSNE;                   /** GPGPU t-SNE gradient descent implementation */
+    GradientDescentCPU                       _CPU_tSNE;                     /** CPU t-SNE gradient descent implementation */
     hdi::data::Embedding<float>             _embedding;                     /** Storage of current embedding */
     TsneData                                _outEmbedding;                  /** Transfer embedding data array */
     OffscreenBuffer*                        _offscreenBuffer;               /** Offscreen OpenGL buffer required to run the gradient descent */

--- a/src/Common/TsneParameters.h
+++ b/src/Common/TsneParameters.h
@@ -1,6 +1,6 @@
 #pragma once
 
-enum class GradienDescentType
+enum class GradientDescentType
 {
     GPU,
     CPU,
@@ -19,7 +19,7 @@ public:
         _presetEmbedding(false),
         _exaggerationFactor(4),
         _updateCore(10),
-        _gradienDescentType(GradienDescentType::GPU)
+        _gradientDescentType(GradientDescentType::GPU)
     {
 
     }
@@ -31,7 +31,7 @@ public:
     void setNumDimensionsOutput(int numDimensionsOutput) { _numDimensionsOutput = numDimensionsOutput; }
     void setPresetEmbedding(bool presetEmbedding) { _presetEmbedding = presetEmbedding; }
     void setExaggerationFactor(double exaggerationFactor) { _exaggerationFactor = exaggerationFactor; }
-    void setGradienDescentType(GradienDescentType gradienDescentType) { _gradienDescentType = gradienDescentType; }
+    void setGradientDescentType(GradientDescentType gradientDescentType) { _gradientDescentType = gradientDescentType; }
     void setUpdateCore(int updateCore) { _updateCore = updateCore; }
 
     int getNumIterations() const { return _numIterations; }
@@ -41,7 +41,7 @@ public:
     int getNumDimensionsOutput() const { return _numDimensionsOutput; }
     int getPresetEmbedding() const { return _presetEmbedding; }
     int getExaggerationFactor() const { return _exaggerationFactor; }
-    GradienDescentType getGradienDescentType() const { return _gradienDescentType; }
+    GradientDescentType getGradientDescentType() const { return _gradientDescentType; }
     int getUpdateCore() const { return _updateCore; }
 
 private:
@@ -52,7 +52,7 @@ private:
     int _numDimensionsOutput;
     double _exaggerationFactor;
     bool _presetEmbedding;
-    GradienDescentType _gradienDescentType;     // Whether to use CPU or GPU gradient descent
+    GradientDescentType _gradientDescentType;     // Whether to use CPU or GPU gradient descent
 
     int _updateCore;        // Gradient descent iterations after which the embedding data set in ManiVault's core will be updated
 };

--- a/src/tSNE/InitTsneSettings.h
+++ b/src/tSNE/InitTsneSettings.h
@@ -26,17 +26,13 @@ public:
      * Constructor
      * @param tsneSettingsAction Reference to TSNE settings action
      */
-    InitTsneSettings(TsneSettingsAction& tsneSettingsAction);
+    InitTsneSettings(TsneSettingsAction& tsneSettingsAction, size_t numPointsInputData);
 
     std::vector<float> getInitEmbedding(size_t numPoints);
 
     void updateSeed();
 
-    /**
-     * only list point datasets with at least 2 dimensions
-     * and the same number of points as the input data
-    */
-    void updateDataPicker(size_t numPointsInputData);
+    void updateDatasetPicker();
 
 public: // Action getters
 

--- a/src/tSNE/TsneSettingsAction.cpp
+++ b/src/tSNE/TsneSettingsAction.cpp
@@ -4,12 +4,12 @@
 
 using namespace mv::gui;
 
-TsneSettingsAction::TsneSettingsAction(QObject* parent) :
+TsneSettingsAction::TsneSettingsAction(QObject* parent, size_t numPointsInputData) :
     GroupAction(parent, "TSNE Settings"),
     _tsneParameters(),
     _knnParameters(),
     _generalTsneSettingsAction(*this),
-    _initTsneSettingsAction(*this),
+    _initTsneSettingsAction(*this, numPointsInputData),
     _gradientDescentSettingsAction(this, _tsneParameters),
     _knnSettingsAction(this, _knnParameters)
 {

--- a/src/tSNE/TsneSettingsAction.h
+++ b/src/tSNE/TsneSettingsAction.h
@@ -28,7 +28,7 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      */
-    TsneSettingsAction(QObject* parent);
+    TsneSettingsAction(QObject* parent, size_t numPointsInputData);
 
     /**
      * Get the context menu for the action


### PR DESCRIPTION
The `DatasetPickerAction _datasetInitAction`  in `InitTsneSettings` does not update it's dataset list with data sets created after the current t-SNE Analysis. This is due to it's filter function, which checks if a new data set has the same number of points as the current embedding. But since a dataset is typically first added to the core and then populated with actual data, the new dataset has 0 points when the `DatasetPickerAction` encounters it.

This PR fixes the above issue by updating the `DatasetPickerAction` when datasets are changed. This is a very cheap operation and does not slow anything down, as far as I can see in my testing.

Drive-by changes:
- Fix several typoes ("Gradien..." and "Gadien...")
- Set minimum possible number of exaggeration iterations in UI to 0 (from previously 1)