### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 # Dependencies
 # -----------------------------------------------------------------------------
 
-find_package(Qt6 6.3.1 COMPONENTS Widgets WebEngineWidgets REQUIRED)
+find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG)
 
@@ -82,7 +82,6 @@ endif()
 
 find_package(lz4 CONFIG REQUIRED)
 find_package(flann CONFIG REQUIRED)
-cmake_policy(SET CMP0144 NEW)
 find_package(HDILib COMPONENTS hdidimensionalityreduction hdiutils hdidata CONFIG REQUIRED)
 
 if(${HDILib_FOUND})


### PR DESCRIPTION
- WIth cmake 3.27 CMP0144 is automatically set to NEW
- We provide Qt 6.3.2 on the CI and that apparently wasn't checked strictly in earlier cmake versions