### PR TITLE
Use readme as help menu entry

### DIFF
--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -14,6 +14,7 @@
 #include <actions/PluginTriggerAction.h>
 #include <event/Event.h>
 #include <util/Icon.h>
+#include <widgets/MarkdownDialog.h>
 
 #include "hdi/dimensionality_reduction/hierarchical_sne.h"
 
@@ -465,11 +466,33 @@ AnalysisPlugin* HsneAnalysisPluginFactory::produce()
 HsneAnalysisPluginFactory::HsneAnalysisPluginFactory()
 {
     setIcon(StyledIcon(createPluginIcon("HSNE")));
+
+    connect(&getPluginMetadata().getTriggerHelpAction(), &TriggerAction::triggered, this, [this]() -> void {
+        if (!getReadmeMarkdownUrl().isValid() || _helpMarkdownDialog.get())
+            return;
+
+        _helpMarkdownDialog = new util::MarkdownDialog(getReadmeMarkdownUrl());
+
+        _helpMarkdownDialog->setWindowTitle(QString("%1").arg(getKind()));
+        _helpMarkdownDialog->setAttribute(Qt::WA_DeleteOnClose);
+        _helpMarkdownDialog->setWindowModality(Qt::NonModal);
+        _helpMarkdownDialog->show();
+        });
 }
 
 mv::DataTypes HsneAnalysisPluginFactory::supportedDataTypes() const
 {
     return { PointType };
+}
+
+QUrl HsneAnalysisPluginFactory::getReadmeMarkdownUrl() const
+{
+    return QUrl("https://raw.githubusercontent.com/ManiVaultStudio/t-SNE-Analysis/master/README.md");
+}
+
+QUrl HsneAnalysisPluginFactory::getRepositoryUrl() const
+{
+    return QUrl("https://github.com/ManiVaultStudio/t-SNE-Analysis");
 }
 
 PluginTriggerActions HsneAnalysisPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const

--- a/src/HSNE/HsneAnalysisPlugin.h
+++ b/src/HSNE/HsneAnalysisPlugin.h
@@ -8,10 +8,17 @@
 #include "HsneSettingsAction.h"
 #include "TsneAnalysis.h"
 
+#include <QPointer>
+#include <QUrl>
+
 using namespace mv::plugin;
 using namespace mv::gui;
 
 class HsneScaleAction;
+
+namespace mv::util {
+    class MarkdownDialog;
+}
 
 /**
  * HsneAnalysisPlugin
@@ -91,4 +98,13 @@ public:
      * @return Vector of plugin trigger actions
      */
     PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
+
+    QUrl getReadmeMarkdownUrl() const override;
+
+    bool hasHelp() const override { return true; }
+
+    QUrl getRepositoryUrl() const override;
+
+private:
+    QPointer<mv::util::MarkdownDialog>   _helpMarkdownDialog = {};
 };

--- a/src/tSNE/TsneAnalysisPlugin.cpp
+++ b/src/tSNE/TsneAnalysisPlugin.cpp
@@ -8,6 +8,7 @@
 
 #include <event/Event.h>
 #include <util/Icon.h>
+#include <widgets/MarkdownDialog.h>
 
 #include <actions/PluginTriggerAction.h>
 
@@ -340,11 +341,33 @@ AnalysisPlugin* TsneAnalysisPluginFactory::produce()
 TsneAnalysisPluginFactory::TsneAnalysisPluginFactory()
 {
     setIcon(StyledIcon(createPluginIcon("TSNE")));
+
+    connect(&getPluginMetadata().getTriggerHelpAction(), &TriggerAction::triggered, this, [this]() -> void {
+        if (!getReadmeMarkdownUrl().isValid() || _helpMarkdownDialog.get())
+            return;
+
+        _helpMarkdownDialog = new util::MarkdownDialog(getReadmeMarkdownUrl());
+
+        _helpMarkdownDialog->setWindowTitle(QString("%1").arg(getKind()));
+        _helpMarkdownDialog->setAttribute(Qt::WA_DeleteOnClose);
+        _helpMarkdownDialog->setWindowModality(Qt::NonModal);
+        _helpMarkdownDialog->show();
+        });
 }
 
 mv::DataTypes TsneAnalysisPluginFactory::supportedDataTypes() const
 {
     return { PointType };
+}
+
+QUrl TsneAnalysisPluginFactory::getReadmeMarkdownUrl() const
+{
+    return QUrl("https://raw.githubusercontent.com/ManiVaultStudio/t-SNE-Analysis/master/README.md");
+}
+
+QUrl TsneAnalysisPluginFactory::getRepositoryUrl() const
+{
+    return QUrl("https://github.com/ManiVaultStudio/t-SNE-Analysis");
 }
 
 PluginTriggerActions TsneAnalysisPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const

--- a/src/tSNE/TsneAnalysisPlugin.h
+++ b/src/tSNE/TsneAnalysisPlugin.h
@@ -5,10 +5,17 @@
 
 #include "TsneAnalysis.h"
 
+#include <QPointer>
+#include <QUrl>
+
 using namespace mv::plugin;
 using namespace mv::gui;
 
 class TsneSettingsAction;
+
+namespace mv::util {
+    class MarkdownDialog;
+}
 
 class TsneAnalysisPlugin : public AnalysisPlugin
 {
@@ -73,4 +80,13 @@ public:
      * @return Vector of plugin trigger actions
      */
     PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
+
+    QUrl getReadmeMarkdownUrl() const override;
+
+    bool hasHelp() const override { return true; }
+
+    QUrl getRepositoryUrl() const override;
+
+private:
+    QPointer<mv::util::MarkdownDialog>   _helpMarkdownDialog = {};
 };


### PR DESCRIPTION
Show the README of this repo has a markdown in the help menu, same as https://github.com/ManiVaultStudio/UMAP-Plugin/pull/11.

See [Plugin help menu entry](https://github.com/ManiVaultStudio/DeveloperWiki/wiki/Plugin-Structure#plugin-help-menu-entry) in the wiki.