### PR TITLE
Use HNSW as default knn algorithm

### DIFF
--- a/src/HSNE/GeneralHsneSettingsAction.cpp
+++ b/src/HSNE/GeneralHsneSettingsAction.cpp
@@ -27,7 +27,7 @@ GeneralHsneSettingsAction::GeneralHsneSettingsAction(HsneSettingsAction& hsneSet
     _numKnnAction.setDefaultWidgetFlags(IntegralAction::SpinBox | IntegralAction::Slider);
 
     _numScalesAction.initialize(1, 10, hsneSettingsAction.getHsneParameters().getNumScales());
-    _knnAlgorithmAction.initialize(QStringList({ "FLANN", "HNSW", "ANNOY" }), "FLANN");
+    _knnAlgorithmAction.initialize(QStringList({ "FLANN", "HNSW", "ANNOY" }), "HNSW");
     _distanceMetricAction.initialize(QStringList({ "Euclidean", "Cosine", "Inner Product", "Manhattan", "Hamming", "Dot" }), "Euclidean");
     _numKnnAction.initialize(3, 300, 90);
 

--- a/src/tSNE/GeneralTsneSettingsAction.cpp
+++ b/src/tSNE/GeneralTsneSettingsAction.cpp
@@ -26,7 +26,7 @@ GeneralTsneSettingsAction::GeneralTsneSettingsAction(TsneSettingsAction& tsneSet
     _distanceMetricAction.setDefaultWidgetFlags(OptionAction::ComboBox);
     _perplexityAction.setDefaultWidgetFlags(IntegralAction::SpinBox | IntegralAction::Slider);
 
-    _knnAlgorithmAction.initialize(QStringList({ "FLANN", "HNSW", "ANNOY" }), "FLANN");
+    _knnAlgorithmAction.initialize(QStringList({ "FLANN", "HNSW", "ANNOY" }), "HNSW");
     _distanceMetricAction.initialize(QStringList({ "Euclidean", "Cosine", "Inner Product", "Manhattan", "Hamming", "Dot" }), "Euclidean");
     _perplexityAction.initialize(2, 50, 30);
 


### PR DESCRIPTION
We should slowly phase-out using FLANN by starting to switch defaults.
Using HNSW for knn computation aligns better with many other DR technique implementations. 