### PR TITLE
Uses glad for OpenGL on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lz4.tgz
 lz4_Debug.tgz
 lz4_Release.tgz
 *.bak
+.DS_Store

--- a/src/Common/OffscreenBuffer.cpp
+++ b/src/Common/OffscreenBuffer.cpp
@@ -3,7 +3,8 @@
 #include "OffscreenBuffer.h"
 
 OffscreenBuffer::OffscreenBuffer() :
-    _context(nullptr)
+    _context(nullptr),
+    _surface(nullptr)
 {
     setSurfaceType(QWindow::OpenGLSurface);
 
@@ -19,20 +20,37 @@ void OffscreenBuffer::initialize()
     if (!_context->create())
         qFatal("Cannot create requested OpenGL context.");
 
+    // Create an offscreen surface (on the GUI thread) matching the context
+    // format. The context is later made current on this surface from the worker
+    // thread; using the QWindow itself as the surface fails on macOS.
+    _surface = new QOffscreenSurface();
+    _surface->setFormat(_context->format());
+    _surface->create();
+
     bindContext();
 
-#ifndef __APPLE__
+#ifdef __APPLE__
+    // On macOS, Qt 6 provides OpenGL over Metal and exposes it only through the
+    // context's getProcAddress; the system OpenGL framework symbols are not
+    // bound to it. Load glad via Qt so HDILib's (glad-based) GL calls reach the
+    // live context. Must be done with the context current (bindContext above).
+    if (!gladLoadGLLoader((GLADloadproc)[](const char* name) -> void* {
+            QOpenGLContext* ctx = QOpenGLContext::currentContext();
+            return ctx ? reinterpret_cast<void*>(ctx->getProcAddress(name)) : nullptr;
+        }))
+        qFatal("Failed to load OpenGL functions via Qt getProcAddress on macOS.");
+#else
     if (!gladLoadGL()) {
         qFatal("No OpenGL context is currently bound, therefore OpenGL function loading has failed.");
     }
-#endif // Not __APPLE__
+#endif
 
     releaseContext();
 }
 
 void OffscreenBuffer::bindContext()
 {
-    _context->makeCurrent(this);
+    _context->makeCurrent(_surface);
 }
 
 void OffscreenBuffer::releaseContext()

--- a/src/Common/OffscreenBuffer.h
+++ b/src/Common/OffscreenBuffer.h
@@ -2,6 +2,7 @@
 
 #include <QWindow>
 #include <QOpenGLContext>
+#include <QOffscreenSurface>
 
 class OffscreenBuffer : public QWindow
 {
@@ -9,6 +10,13 @@ public:
     OffscreenBuffer();
 
     QOpenGLContext* getContext() { return _context; }
+
+    /** The surface the context is made current on. A QOffscreenSurface (rather
+     *  than the QWindow itself) is required so the context can be made current
+     *  on a worker thread - a never-shown QWindow has no valid native surface
+     *  off the main thread on macOS, making makeCurrent succeed but leave no
+     *  usable context. */
+    QOffscreenSurface* getSurface() { return _surface; }
 
     /** Initialize and bind the OpenGL context associated with this buffer */
     void initialize();
@@ -21,4 +29,5 @@ public:
 
 private:
     QOpenGLContext* _context;
+    QOffscreenSurface* _surface;
 };

--- a/src/Common/TsneAnalysis.cpp
+++ b/src/Common/TsneAnalysis.cpp
@@ -1,10 +1,9 @@
 #include "TsneAnalysis.h"
 
-#ifdef __APPLE__
-    #include <OpenGL/gl3.h>
-#else // __APPLE__
-    #include "hdi/utils/glad/glad.h"
-#endif // __APPLE__
+// Use glad on all platforms (incl. macOS) to match HDILib. Mixing the macOS
+// OpenGL framework header with glad in one translation unit produces duplicate
+// GL definitions, and the framework symbols aren't bound to Qt's context anyway.
+#include "hdi/utils/glad/glad.h"
  
 #include "OffscreenBuffer.h"
 
@@ -109,6 +108,7 @@ void TsneWorker::changeThread(QThread* targetThread)
     // Move the Offscreen buffer to the processing thread after creating it in the UI Thread
     _offscreenBuffer->moveToThread(targetThread);
     _offscreenBuffer->getContext()->moveToThread(targetThread);
+    _offscreenBuffer->getSurface()->moveToThread(targetThread);
 }
 
 void TsneWorker::resetThread()


### PR DESCRIPTION
This reworks the GPU version to use glad for OpenGL on all platforms. It also explicitly sets the OpenGL surface to the worker thread. Both are intended to fix the OpenGL HDI pipeline on macOS.
This is probably at best a fallback for the new Vulkan codepath, but it seemed bad to leave a broken codepath even if not used.

**Requires** HDI with glad enabled for macOS available in this PR https://github.com/biovault/HDILib/pull/83

Given the HDI change this should also not work with the binaries from the artifactory. Hence, this needs adjustments to that pipeline. I have only worked with self build HDI.