### PR TITLE
Feature/serialization issues

### DIFF
--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -67,6 +67,35 @@ namespace
         return bytes;
     }
 
+    /**
+     * Write a buffer to file in bounded chunks rather than a single write().
+     * Mirrors readFileInChunks(): a single QFile::write() hassimilar issues as described above
+     */
+    void writeFileInChunks(const QString& filePath, const QByteArray& bytes)
+    {
+        QFile file(filePath);
+
+        if (!file.open(QIODevice::WriteOnly))
+            throw std::runtime_error(QString("Failed to open output file '%1'").arg(filePath).toStdString());
+
+        constexpr qint64 chunkSize = 512LL * 1024 * 1024;
+
+        qint64 written = 0;
+
+        while (written < bytes.size()) {
+            const auto size = std::min(chunkSize, static_cast<qint64>(bytes.size()) - written);
+            const auto result = file.write(bytes.constData() + written, size);
+
+            if (result <= 0)
+                throw std::runtime_error(QString("Failed to write file '%1': %2").arg(filePath, file.errorString()).toStdString());
+
+            written += result;
+        }
+
+        file.close();
+    }
+}
+
 HsneAnalysisPlugin::HsneAnalysisPlugin(const PluginFactory* factory) :
     AnalysisPlugin(factory),
     _hierarchy(std::make_unique<HsneHierarchy>()),
@@ -454,15 +483,7 @@ void HsneAnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
                 const auto hsneHierarchyRawMap  = variantMap["HsneHierarchyRaw"].toMap();
                 const auto restored             = bytesFromBlobVariantMap(hsneHierarchyRawMap);
 
-                QFile file(loadPathHierarchy);
-
-                if (!file.open(QIODevice::WriteOnly))
-                    throw std::runtime_error("Failed to open output file");
-
-                if (file.write(restored) != restored.size())
-                    throw std::runtime_error("Failed to write output file");
-
-                file.close();
+                writeFileInChunks(loadPathHierarchy, restored);
             } else {
                 loadPathHierarchy = mv::projects().extractFileFromManiVaultProject(mv::projects().getCurrentProject()->getFilePath(), tempDir, variantMap["HsneHierarchy"].toString());
             }
@@ -476,15 +497,7 @@ void HsneAnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
                 const auto hsneInfluenceHierarchyRawMap = variantMap["HsneInfluenceHierarchyRaw"].toMap();
                 const auto restored                     = bytesFromBlobVariantMap(hsneInfluenceHierarchyRawMap);
 
-                QFile file(loadPathInfluenceHierarchy);
-
-                if (!file.open(QIODevice::WriteOnly))
-                    throw std::runtime_error("Failed to open output file");
-
-                if (file.write(restored) != restored.size())
-                    throw std::runtime_error("Failed to write output file");
-
-                file.close();
+                writeFileInChunks(loadPathInfluenceHierarchy, restored);
             }
             else {
                 loadPathInfluenceHierarchy = mv::projects().extractFileFromManiVaultProject(mv::projects().getCurrentProject()->getFilePath(), tempDir, variantMap["HsneInfluenceHierarchy"].toString());

--- a/src/HSNE/HsneAnalysisPlugin.cpp
+++ b/src/HSNE/HsneAnalysisPlugin.cpp
@@ -20,6 +20,8 @@
 
 #include "hdi/dimensionality_reduction/hierarchical_sne.h"
 
+#include <QFileInfo>
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -30,6 +32,40 @@ Q_PLUGIN_METADATA(IID "studio.manivault.HsneAnalysisPlugin")
 
 using namespace mv;
 using namespace mv::util;
+
+namespace
+{
+    /**
+     * Read a file in chunks
+     *
+     * A single QFile::readAll() issues one native read() call sized to the full file.
+     * On macOS (and other platforms) that syscall fails for large files (> 2@GB)
+     */
+    QByteArray readFileInChunks(const QString& filePath)
+    {
+        QFile file(filePath);
+
+        if (!file.open(QIODevice::ReadOnly))
+            throw std::runtime_error(QString("Failed to open input file '%1'").arg(filePath).toStdString());
+
+        const qint64 totalSize = file.size();
+
+        constexpr qint64 chunkSize = 512LL * 1024 * 1024;
+
+        QByteArray bytes;
+        bytes.reserve(static_cast<qsizetype>(totalSize));
+
+        while (bytes.size() < totalSize) {
+            const auto chunk = file.read(std::min(chunkSize, totalSize - bytes.size()));
+
+            if (chunk.isEmpty())
+                throw std::runtime_error(QString("Failed to read file '%1': %2").arg(filePath, file.errorString()).toStdString());
+
+            bytes.append(chunk);
+        }
+
+        return bytes;
+    }
 
 HsneAnalysisPlugin::HsneAnalysisPlugin(const PluginFactory* factory) :
     AnalysisPlugin(factory),
@@ -505,12 +541,7 @@ QVariantMap HsneAnalysisPlugin::toVariantMap() const
                 variantMap["HsneHierarchy"] = fileName;
             }
 
-            QFile file(QString::fromStdString(filePath));
-
-            if (!file.open(QIODevice::ReadOnly))
-                throw std::runtime_error("Failed to open input file");
-
-            const auto bytes = file.readAll();
+            const auto bytes = readFileInChunks(QString::fromStdString(filePath));
 
             variantMap["HsneHierarchyRaw"] = bytesToBlobVariantMap(bytes.constData(), static_cast<std::uint64_t>(bytes.size()));
         }
@@ -527,12 +558,7 @@ QVariantMap HsneAnalysisPlugin::toVariantMap() const
             _hierarchy->saveCacheHsneInfluenceHierarchy(filePath, _hierarchy->getInfluenceHierarchy().getMap());
             variantMap["HsneInfluenceHierarchy"] = fileName;
 
-            QFile file(QString::fromStdString(filePath));
-
-            if (!file.open(QIODevice::ReadOnly))
-                throw std::runtime_error("Failed to open input file");
-
-            const auto bytes = file.readAll();
+            const auto bytes = readFileInChunks(QString::fromStdString(filePath));
 
             variantMap["HsneInfluenceHierarchyRaw"] = bytesToBlobVariantMap(bytes.constData(), static_cast<std::uint64_t>(bytes.size()));
         }


### PR DESCRIPTION
During (de-)serialization the HSNE plugin is reading (writing) a temporary file to disk containing the HSNE hierarchy. The full hierarchy tends to get very big quickly (my test case was an 8GB hierarchy for a 600MB raw binary data file).

The current implementation uses qt io readAll() and write(). Which are mapped to native read()/write() calls for the complete file. For readAll() a fail in the native call will simply return an empty array, but no error, making serialization seemingly fine.
On macOS (and possible other *nixes) the kernel caps read()/write() at INT_MAX, so serialization for the above mentioned dataset would create a project missing the HSNE hierarchy, which on load would error. Fixing the serialization surfaced the same issue with writing in de-serialization.

Both are fixed here with chunked versions of read and write.

